### PR TITLE
Feat: impl QueryFinalityProviderHasPower in consumer chain

### DIFF
--- a/clientcontroller/opstackl2/consumer.go
+++ b/clientcontroller/opstackl2/consumer.go
@@ -299,6 +299,10 @@ func (cc *OPStackL2ConsumerController) QueryLatestFinalizedBlock() (*types.Block
 		return nil, err
 	}
 
+	if l2Block.Number.Uint64() == 0 {
+		return nil, nil
+	}
+
 	return &types.BlockInfo{
 		Height: l2Block.Number.Uint64(),
 		Hash:   l2Block.Hash().Bytes(),
@@ -387,6 +391,10 @@ func (cc *OPStackL2ConsumerController) QueryIsBlockFinalized(height uint64) (boo
 	l2Block, err := cc.QueryLatestFinalizedBlock()
 	if err != nil {
 		return false, err
+	}
+
+	if l2Block == nil {
+		return false, nil
 	}
 	if height > l2Block.Height {
 		return false, nil

--- a/clientcontroller/opstackl2/consumer.go
+++ b/clientcontroller/opstackl2/consumer.go
@@ -298,6 +298,9 @@ func (cc *OPStackL2ConsumerController) QueryLatestFinalizedBlock() (*types.Block
 	if err != nil {
 		return nil, err
 	}
+	if l2Block.Number.Uint64() == 0 {
+		return nil, nil
+	}
 	return &types.BlockInfo{
 		Height: l2Block.Number.Uint64(),
 		Hash:   l2Block.Hash().Bytes(),
@@ -538,6 +541,11 @@ func (cc *OPStackL2ConsumerController) GetBlockHeightByL2Timestamp(l2Timestamp u
 
 	for lowerBound <= upperBound {
 		midHeight := lowerBound + (upperBound-lowerBound)/2
+
+		// special case when the timestamp is near the genesis block
+		if midHeight == 0 {
+			return 1, nil
+		}
 
 		bbnBlock, err := cc.bbnClient.RPCClient.Block(context.Background(), &midHeight)
 		if err != nil {

--- a/clientcontroller/opstackl2/consumer.go
+++ b/clientcontroller/opstackl2/consumer.go
@@ -298,9 +298,7 @@ func (cc *OPStackL2ConsumerController) QueryLatestFinalizedBlock() (*types.Block
 	if err != nil {
 		return nil, err
 	}
-	if l2Block.Number.Uint64() == 0 {
-		return nil, nil
-	}
+
 	return &types.BlockInfo{
 		Height: l2Block.Number.Uint64(),
 		Hash:   l2Block.Hash().Bytes(),

--- a/finality-provider/config/opstackl2.go
+++ b/finality-provider/config/opstackl2.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	cwcfg "github.com/babylonlabs-io/finality-provider/cosmwasmclient/config"
+
 	"github.com/cosmos/btcutil/bech32"
 )
 
@@ -76,5 +77,23 @@ func (cfg *OPStackL2Config) ToCosmwasmConfig() cwcfg.CosmwasmConfig {
 		OutputFormat:     cfg.OutputFormat,
 		SignModeStr:      cfg.SignModeStr,
 		SubmitterAddress: "",
+	}
+}
+
+func (cfg *OPStackL2Config) ToBBNConfig() BBNConfig {
+	return BBNConfig{
+		Key:            cfg.Key,
+		ChainID:        cfg.ChainID,
+		RPCAddr:        cfg.RPCAddr,
+		AccountPrefix:  cfg.AccountPrefix,
+		KeyringBackend: cfg.KeyringBackend,
+		GasAdjustment:  cfg.GasAdjustment,
+		GasPrices:      cfg.GasPrices,
+		KeyDirectory:   cfg.KeyDirectory,
+		Debug:          cfg.Debug,
+		Timeout:        cfg.Timeout,
+		BlockTimeout:   cfg.BlockTimeout,
+		OutputFormat:   cfg.OutputFormat,
+		SignModeStr:    cfg.SignModeStr,
 	}
 }

--- a/finality-provider/service/fp_instance.go
+++ b/finality-provider/service/fp_instance.go
@@ -434,7 +434,10 @@ func (fp *FinalityProviderInstance) tryFastSync(targetBlockHeight uint64) (*Fast
 	}
 
 	fp.logger.Debug("the finality-provider is entering fast sync",
-		zap.Uint64("start_height", startHeight), zap.Uint64("target_block_height", targetBlockHeight))
+		zap.String("pk", fp.GetBtcPkHex()),
+		zap.Uint64("start_height", startHeight),
+		zap.Uint64("target_block_height", targetBlockHeight),
+	)
 
 	return fp.FastSync(startHeight, targetBlockHeight)
 }

--- a/itest/opstackl2/README.md
+++ b/itest/opstackl2/README.md
@@ -12,5 +12,5 @@ Then run the following command to start the e2e tests:
 $ make test-e2e-op
 
 # Filter specific test
-$ make test-e2e-op Filter=TestFinalityGadget
+$ make test-e2e-op FILTER=TestFinalityGadget
 ```

--- a/itest/opstackl2/op_e2e_test.go
+++ b/itest/opstackl2/op_e2e_test.go
@@ -27,7 +27,7 @@ func TestOpSubmitFinalitySignature(t *testing.T) {
 
 	e2eutils.WaitForFpPubRandCommitted(t, fpInstance)
 	// query the first committed pub rand
-	opcc := ctm.getOpCCAtIndex(1)
+	opcc := ctm.getOpCCAtIndex(0)
 	committedPubRand, err := queryFirstPublicRandCommit(opcc, fpInstance.GetBtcPk())
 	require.NoError(t, err)
 	committedStartHeight := committedPubRand.StartHeight
@@ -65,8 +65,9 @@ func TestOpMultipleFinalityProviders(t *testing.T) {
 		{e2eutils.StakingTime, e2eutils.StakingAmount},
 	})
 
-	// wait until the BTC staking is activated
-	l2BlockAfterActivation := ctm.waitForBTCStakingActivation(t)
+	// BTC delegations are activated after SetupFinalityProviders
+	l2BlockAfterActivation, err := ctm.getOpCCAtIndex(0).QueryLatestBlockHeight()
+	require.NoError(t, err)
 
 	// check both FPs have committed their first public randomness
 	// TODO: we might use go routine to do this in parallel
@@ -156,7 +157,7 @@ func TestFinalityStuckAndRecover(t *testing.T) {
 	t.Logf(log.Prefix("last voted height %d"), lastVotedHeight)
 	// wait until the block finalized
 	require.Eventually(t, func() bool {
-		latestFinalizedBlock, err := ctm.getOpCCAtIndex(1).QueryLatestFinalizedBlock()
+		latestFinalizedBlock, err := ctm.getOpCCAtIndex(0).QueryLatestFinalizedBlock()
 		require.NoError(t, err)
 		if latestFinalizedBlock == nil {
 			return false
@@ -167,7 +168,7 @@ func TestFinalityStuckAndRecover(t *testing.T) {
 
 	// check the finality gets stuck. wait for a while to make sure it is stuck
 	time.Sleep(5 * ctm.getL1BlockTime())
-	latestFinalizedBlock, err := ctm.getOpCCAtIndex(1).QueryLatestFinalizedBlock()
+	latestFinalizedBlock, err := ctm.getOpCCAtIndex(0).QueryLatestFinalizedBlock()
 	require.NoError(t, err)
 	require.NotNil(t, latestFinalizedBlock)
 	stuckHeight := latestFinalizedBlock.Height

--- a/itest/opstackl2/op_e2e_test.go
+++ b/itest/opstackl2/op_e2e_test.go
@@ -158,6 +158,9 @@ func TestFinalityStuckAndRecover(t *testing.T) {
 	require.Eventually(t, func() bool {
 		latestFinalizedBlock, err := ctm.getOpCCAtIndex(1).QueryLatestFinalizedBlock()
 		require.NoError(t, err)
+		if latestFinalizedBlock == nil {
+			return false
+		}
 		stuckHeight := latestFinalizedBlock.Height
 		return lastVotedHeight == stuckHeight
 	}, e2eutils.EventuallyWaitTimeOut, e2eutils.EventuallyPollTime)
@@ -166,6 +169,7 @@ func TestFinalityStuckAndRecover(t *testing.T) {
 	time.Sleep(5 * ctm.getL1BlockTime())
 	latestFinalizedBlock, err := ctm.getOpCCAtIndex(1).QueryLatestFinalizedBlock()
 	require.NoError(t, err)
+	require.NotNil(t, latestFinalizedBlock)
 	stuckHeight := latestFinalizedBlock.Height
 	require.Equal(t, lastVotedHeight, stuckHeight)
 	t.Logf(log.Prefix("OP chain block finalized head stuck at height %d"), stuckHeight)

--- a/itest/opstackl2/op_test_manager.go
+++ b/itest/opstackl2/op_test_manager.go
@@ -831,6 +831,9 @@ func (ctm *OpL2ConsumerTestManager) WaitForBlockFinalized(
 			t.Logf(log.Prefix("failed to query latest finalized block %s"), err.Error())
 			return false
 		}
+		if latestFinalizedBlock == nil {
+			return false
+		}
 		finalizedBlockHeight = latestFinalizedBlock.Height
 		return finalizedBlockHeight >= checkedHeight
 	}, e2eutils.EventuallyWaitTimeOut, 5*ctm.getL2BlockTime())

--- a/itest/opstackl2/op_test_manager.go
+++ b/itest/opstackl2/op_test_manager.go
@@ -102,7 +102,7 @@ func StartOpL2ConsumerManager(t *testing.T, numOfConsumerFPs uint8) *OpL2Consume
 		testDir,
 		bh,
 		opL2ConsumerConfig,
-		numOfConsumerFPs+1,
+		numOfConsumerFPs,
 		logger,
 		&shutdownInterceptor,
 		t,
@@ -765,7 +765,7 @@ func (ctm *OpL2ConsumerTestManager) SetupFinalityProviders(
 	for i := 0; i < n; i++ {
 		ctm.InsertBTCDelegation(
 			t,
-			[]*btcec.PublicKey{bbnFpPk.MustToBTCPK(), consumerFpPkList[0].MustToBTCPK()},
+			[]*btcec.PublicKey{bbnFpPk.MustToBTCPK(), consumerFpPkList[i].MustToBTCPK()},
 			stakingParams[i].stakingTime,
 			stakingParams[i].stakingAmount,
 		)

--- a/itest/opstackl2/op_test_manager.go
+++ b/itest/opstackl2/op_test_manager.go
@@ -937,29 +937,6 @@ func queryFirstOrLastPublicRandCommit(
 	return resp, nil
 }
 
-func (ctm *OpL2ConsumerTestManager) waitForBTCStakingActivation(t *testing.T) uint64 {
-	var l2BlockAfterActivation uint64
-	require.Eventually(t, func() bool {
-		latestBlockHeight, err := ctm.getOpCCAtIndex(0).QueryLatestBlockHeight()
-		require.NoError(t, err)
-		latestBlock, err := ctm.getOpCCAtIndex(0).QueryEthBlock(latestBlockHeight)
-		require.NoError(t, err)
-		l2BlockAfterActivation = latestBlock.Number.Uint64()
-
-		activatedTimestamp, err := ctm.FinalityGadget.QueryBtcStakingActivatedTimestamp()
-		if err != nil {
-			t.Logf(log.Prefix("Failed to query BTC staking activated timestamp: %v"), err)
-			return false
-		}
-		t.Logf(log.Prefix("Activated timestamp %d"), activatedTimestamp)
-
-		return latestBlock.Time >= activatedTimestamp
-	}, 30*ctm.getL2BlockTime(), ctm.getL2BlockTime())
-
-	t.Logf(log.Prefix("found a L2 block after BTC staking activation: %d"), l2BlockAfterActivation)
-	return l2BlockAfterActivation
-}
-
 func (ctm *OpL2ConsumerTestManager) Stop(t *testing.T) {
 	t.Log("Stopping test manager")
 	var err error


### PR DESCRIPTION
# Summary
context in [#496](https://github.com/babylonchain/finality-provider/issues/496)
This pr implements the logic of querying voting power in Op. 

> instead of querying the exact voting power, the FP queries BTC delegations page by page, and if there is >=1 active BTC delegation, then it can vote.

# Test plan
```
make test-e2e-op
```
