### PR TITLE
chore: keep sync fp status

### DIFF
--- a/clientcontroller/babylon.go
+++ b/clientcontroller/babylon.go
@@ -3,6 +3,7 @@ package clientcontroller
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	sdkErr "cosmossdk.io/errors"
@@ -276,6 +277,12 @@ func (bc *BabylonController) QueryFinalityProviderVotingPower(fpPk *btcec.Public
 		blockHeight,
 	)
 	if err != nil {
+		allowedErr := fmt.Sprintf("rpc error: code = Unknown desc = %s: unknown request", btcstakingtypes.ErrVotingPowerTableNotUpdated.Wrapf("height: %d", blockHeight).Error())
+		if strings.EqualFold(err.Error(), allowedErr) {
+			// if nothing was updated in the voting power table, it should consider as zero VP to start to send pub random
+			return 0, nil
+		}
+
 		return 0, fmt.Errorf("failed to query Finality Voting Power at Height: %w", err)
 	}
 

--- a/clientcontroller/babylon.go
+++ b/clientcontroller/babylon.go
@@ -3,7 +3,6 @@ package clientcontroller
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	sdkErr "cosmossdk.io/errors"
@@ -276,14 +275,8 @@ func (bc *BabylonController) QueryFinalityProviderVotingPower(fpPk *btcec.Public
 		bbntypes.NewBIP340PubKeyFromBTCPK(fpPk).MarshalHex(),
 		blockHeight,
 	)
-
 	if err != nil {
-		allowedErr := fmt.Sprintf("rpc error: code = Unknown desc = %s: unknown request", btcstakingtypes.ErrVotingPowerTableNotUpdated.Wrapf("height: %d", blockHeight).Error())
-		if strings.EqualFold(err.Error(), allowedErr) {
-			// if nothing was updated in the voting power table, it should consider as zero VP to start to send pub random
-			return 0, nil
-		}
-		return 0, fmt.Errorf("failed to query BTC delegations: %w", err)
+		return 0, fmt.Errorf("failed to query Finality Voting Power at Height: %w", err)
 	}
 
 	return res.VotingPower, nil

--- a/clientcontroller/babylon.go
+++ b/clientcontroller/babylon.go
@@ -276,7 +276,7 @@ func (bc *BabylonController) QueryFinalityProviderVotingPower(fpPk *btcec.Public
 		blockHeight,
 	)
 	if err != nil {
-		return 0, fmt.Errorf("failed to query Finality Voting Power at Height: %w", err)
+		return 0, fmt.Errorf("failed to query Finality Voting Power at Height %d: %w", blockHeight, err)
 	}
 
 	return res.VotingPower, nil

--- a/clientcontroller/babylon.go
+++ b/clientcontroller/babylon.go
@@ -2,6 +2,7 @@ package clientcontroller
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -275,6 +276,10 @@ func (bc *BabylonController) QueryFinalityProviderVotingPower(fpPk *btcec.Public
 		bbntypes.NewBIP340PubKeyFromBTCPK(fpPk).MarshalHex(),
 		blockHeight,
 	)
+	if errors.Is(err, btcstakingtypes.ErrVotingPowerTableNotUpdated) {
+		// if nothing was updated in the voting power table
+		return 0, nil
+	}
 	if err != nil {
 		return 0, fmt.Errorf("failed to query BTC delegations: %w", err)
 	}

--- a/clientcontroller/babylon.go
+++ b/clientcontroller/babylon.go
@@ -3,7 +3,6 @@ package clientcontroller
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	sdkErr "cosmossdk.io/errors"
@@ -277,12 +276,6 @@ func (bc *BabylonController) QueryFinalityProviderVotingPower(fpPk *btcec.Public
 		blockHeight,
 	)
 	if err != nil {
-		allowedErr := fmt.Sprintf("rpc error: code = Unknown desc = %s: unknown request", btcstakingtypes.ErrVotingPowerTableNotUpdated.Wrapf("height: %d", blockHeight).Error())
-		if strings.EqualFold(err.Error(), allowedErr) {
-			// if nothing was updated in the voting power table, it should consider as zero VP to start to send pub random
-			return 0, nil
-		}
-
 		return 0, fmt.Errorf("failed to query Finality Voting Power at Height: %w", err)
 	}
 

--- a/clientcontroller/babylon.go
+++ b/clientcontroller/babylon.go
@@ -47,16 +47,18 @@ func NewBabylonController(
 
 	bbnConfig := fpcfg.BBNConfigToBabylonConfig(cfg)
 
-	if err := bbnConfig.Validate(); err != nil {
-		return nil, fmt.Errorf("invalid config for Babylon client: %w", err)
-	}
-
 	bc, err := bbnclient.New(
 		&bbnConfig,
 		logger,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create Babylon client: %w", err)
+	}
+
+	// makes sure that the key in config really exists and it is a valid bech 32 addr
+	// to allow using mustGetTxSigner
+	if _, err := bc.GetAddr(); err != nil {
+		return nil, err
 	}
 
 	return &BabylonController{

--- a/finality-provider/cmd/fpd/daemon/start.go
+++ b/finality-provider/cmd/fpd/daemon/start.go
@@ -111,11 +111,6 @@ func loadApp(
 		return nil, fmt.Errorf("failed to create finality-provider app: %v", err)
 	}
 
-	// sync finality-provider status
-	if err := fpApp.SyncFinalityProviderStatus(); err != nil {
-		return nil, fmt.Errorf("failed to sync finality-provider status: %w", err)
-	}
-
 	return fpApp, nil
 }
 

--- a/finality-provider/config/config.go
+++ b/finality-provider/config/config.go
@@ -32,6 +32,7 @@ const (
 	defaultRandomInterval          = 30 * time.Second
 	defaultSubmitRetryInterval     = 1 * time.Second
 	defaultFastSyncInterval        = 10 * time.Second
+	defaultSyncFpStatusInterval    = 30 * time.Second
 	defaultFastSyncLimit           = 10
 	defaultFastSyncGap             = 3
 	defaultMaxSubmissionRetries    = 20
@@ -69,7 +70,7 @@ type Config struct {
 	FastSyncGap              uint64        `long:"fastsyncgap" description:"The block gap that will trigger the fast sync"`
 	EOTSManagerAddress       string        `long:"eotsmanageraddress" description:"The address of the remote EOTS manager; Empty if the EOTS manager is running locally"`
 	MaxNumFinalityProviders  uint32        `long:"maxnumfinalityproviders" description:"The maximum number of finality-provider instances running concurrently within the daemon"`
-	MinutesToWaitForConsumer uint32        `long:"minuteswaitforconsumer" description:"The number of minutes it should wait for the consumer chain to be available, before stop the app"`
+	SyncFpStatusInterval     time.Duration `long:"syncfpstatusinterval" description:"The duration of time that it should sync FP status with the client blockchain"`
 
 	BitcoinNetwork string `long:"bitcoinnetwork" description:"Bitcoin network to run on" choise:"mainnet" choice:"regtest" choice:"testnet" choice:"simnet" choice:"signet"`
 
@@ -113,7 +114,7 @@ func DefaultConfigWithHome(homePath string) Config {
 		RpcListener:              DefaultRpcListener,
 		MaxNumFinalityProviders:  defaultMaxNumFinalityProviders,
 		Metrics:                  metrics.DefaultFpConfig(),
-		MinutesToWaitForConsumer: 60 * 24 * 7, // one week in minutes
+		SyncFpStatusInterval:     defaultSyncFpStatusInterval,
 	}
 
 	if err := cfg.Validate(); err != nil {

--- a/finality-provider/service/app.go
+++ b/finality-provider/service/app.go
@@ -270,15 +270,18 @@ func (app *FinalityProviderApp) SyncFinalityProviderStatus() error {
 		}
 
 		oldStatus := fp.Status
-		if err := app.fps.UpdateFpStatusFromVotingPower(vp, fp); err != nil {
+		newStatus, err := app.fps.UpdateFpStatusFromVotingPower(vp, fp)
+		if err != nil {
 			return err
 		}
+
 		app.logger.Info(
 			"Update FP status",
 			zap.String("fp_addr", fp.FPAddr),
 			zap.String("old_status", oldStatus.String()),
-			zap.String("new_status", fp.Status.String()),
+			zap.String("new_status", newStatus.String()),
 		)
+		fp.Status = newStatus
 
 		if !fp.ShouldStart() {
 			continue

--- a/finality-provider/service/app.go
+++ b/finality-provider/service/app.go
@@ -255,11 +255,9 @@ func (app *FinalityProviderApp) SyncFinalityProviderStatus() error {
 	for _, fp := range fps {
 		vp, err := app.cc.QueryFinalityProviderVotingPower(fp.BtcPk, latestBlock.Height)
 		if err != nil {
-			if !strings.Contains(err.Error(), bstypes.ErrVotingPowerTableNotUpdated.Wrapf("height: %d", latestBlock.Height).Error()) {
-				// if error occured then the finality-provider is not registered in the Babylon chain yet
-				continue
-			}
-			// if nothing was updated in the voting power table, it should consider as zero VP to start to send pub random
+			// if error occured then the finality-provider is not registered in the Babylon chain yet or
+			// there is nothing in the voting power table, so it should not start the fp.
+			continue
 		}
 
 		if !fp.ShouldSyncStatusFromVotingPower(vp) {

--- a/finality-provider/service/app.go
+++ b/finality-provider/service/app.go
@@ -257,7 +257,11 @@ func (app *FinalityProviderApp) SyncFinalityProviderStatus() error {
 		if err != nil {
 			// if error occured then the finality-provider is not registered in the Babylon chain yet or
 			// there is nothing in the voting power table, so it should not start the fp.
-			continue
+			allowedErr := fmt.Sprintf("failed to query Finality Voting Power at Height: rpc error: code = Unknown desc = %s: unknown request", bstypes.ErrVotingPowerTableNotUpdated.Wrapf("height: %d", latestBlock.Height).Error())
+			if !strings.EqualFold(err.Error(), allowedErr) {
+				// if nothing was updated in the voting power table, it should consider as zero VP to start to send pub random
+				continue
+			}
 		}
 
 		if !fp.ShouldSyncStatusFromVotingPower(vp) {

--- a/finality-provider/service/app.go
+++ b/finality-provider/service/app.go
@@ -668,10 +668,10 @@ func (app *FinalityProviderApp) syncChainFpStatusLoop() {
 	for {
 		select {
 		case <-syncFpStatusTicker.C:
+			app.Logger().Info("running SyncFinalityProviderStatus")
 			// sync finality-provider status
 			if err := app.SyncFinalityProviderStatus(); err != nil {
 				app.Logger().Error("failed to sync finality-provider status", zap.Error(err))
-				continue
 			}
 
 		case <-app.quit:

--- a/finality-provider/service/app.go
+++ b/finality-provider/service/app.go
@@ -257,7 +257,7 @@ func (app *FinalityProviderApp) SyncFinalityProviderStatus() error {
 		if err != nil {
 			// if error occured then the finality-provider is not registered in the Babylon chain yet or
 			// there is nothing in the voting power table, so it should not start the fp.
-			allowedErr := fmt.Sprintf("failed to query Finality Voting Power at Height: rpc error: code = Unknown desc = %s: unknown request", bstypes.ErrVotingPowerTableNotUpdated.Wrapf("height: %d", latestBlock.Height).Error())
+			allowedErr := fmt.Sprintf("failed to query Finality Voting Power at Height %d: rpc error: code = Unknown desc = %s: unknown request", latestBlock.Height, bstypes.ErrVotingPowerTableNotUpdated.Wrapf("height: %d", latestBlock.Height).Error())
 			if !strings.EqualFold(err.Error(), allowedErr) {
 				// if nothing was updated in the voting power table, it should consider as zero VP to start to send pub random
 				continue

--- a/finality-provider/service/app.go
+++ b/finality-provider/service/app.go
@@ -255,8 +255,11 @@ func (app *FinalityProviderApp) SyncFinalityProviderStatus() error {
 	for _, fp := range fps {
 		vp, err := app.cc.QueryFinalityProviderVotingPower(fp.BtcPk, latestBlock.Height)
 		if err != nil {
-			// if error occured then the finality-provider is not registered in the Babylon chain yet
-			continue
+			if !strings.Contains(err.Error(), bstypes.ErrVotingPowerTableNotUpdated.Wrapf("height: %d", latestBlock.Height).Error()) {
+				// if error occured then the finality-provider is not registered in the Babylon chain yet
+				continue
+			}
+			// if nothing was updated in the voting power table, it should consider as zero VP to start to send pub random
 		}
 
 		if !fp.ShouldSyncStatusFromVotingPower(vp) {

--- a/finality-provider/service/chain_poller_test.go
+++ b/finality-provider/service/chain_poller_test.go
@@ -72,6 +72,7 @@ func FuzzChainPoller_Start(f *testing.F) {
 // FuzzChainPoller_SkipHeight tests the functionality of SkipHeight
 func FuzzChainPoller_SkipHeight(f *testing.F) {
 	testutil.AddRandomSeedsToFuzzer(f, 10)
+
 	f.Fuzz(func(t *testing.T, seed int64) {
 		r := rand.New(rand.NewSource(seed))
 

--- a/finality-provider/service/fp_manager.go
+++ b/finality-provider/service/fp_manager.go
@@ -247,15 +247,16 @@ func (fpm *FinalityProviderManager) StartAll() error {
 	}
 
 	for _, fp := range storedFps {
-		if fp.Status == proto.FinalityProviderStatus_CREATED || fp.Status == proto.FinalityProviderStatus_SLASHED {
+		fpBtcPk := fp.GetBIP340BTCPK()
+		if !fp.ShouldStart() {
 			fpm.logger.Info(
 				"the finality provider cannot be started with status",
-				zap.String("eots-pk", fp.GetBIP340BTCPK().MarshalHex()),
+				zap.String("eots-pk", fpBtcPk.MarshalHex()),
 				zap.String("status", fp.Status.String()),
 			)
 			continue
 		}
-		if err := fpm.StartFinalityProvider(fp.GetBIP340BTCPK(), ""); err != nil {
+		if err := fpm.StartFinalityProvider(fpBtcPk, ""); err != nil {
 			return err
 		}
 	}

--- a/finality-provider/store/fpstore.go
+++ b/finality-provider/store/fpstore.go
@@ -117,22 +117,22 @@ func (s *FinalityProviderStore) SetFpStatus(btcPk *btcec.PublicKey, status proto
 func (s *FinalityProviderStore) UpdateFpStatusFromVotingPower(
 	vp uint64,
 	fp *StoredFinalityProvider,
-) error {
+) (proto.FinalityProviderStatus, error) {
 	if vp > 0 {
 		// voting power > 0 then set the status to ACTIVE
-		return s.SetFpStatus(fp.BtcPk, proto.FinalityProviderStatus_ACTIVE)
+		return proto.FinalityProviderStatus_ACTIVE, s.SetFpStatus(fp.BtcPk, proto.FinalityProviderStatus_ACTIVE)
 	}
 
 	// voting power == 0 then set status depending on previous status
 	switch fp.Status {
 	case proto.FinalityProviderStatus_CREATED:
 		// previous status is CREATED then set to REGISTERED
-		return s.SetFpStatus(fp.BtcPk, proto.FinalityProviderStatus_REGISTERED)
+		return proto.FinalityProviderStatus_REGISTERED, s.SetFpStatus(fp.BtcPk, proto.FinalityProviderStatus_REGISTERED)
 	case proto.FinalityProviderStatus_ACTIVE:
 		// previous status is ACTIVE then set to INACTIVE
-		return s.SetFpStatus(fp.BtcPk, proto.FinalityProviderStatus_INACTIVE)
+		return proto.FinalityProviderStatus_INACTIVE, s.SetFpStatus(fp.BtcPk, proto.FinalityProviderStatus_INACTIVE)
 	}
-	return nil
+	return fp.Status, nil
 }
 
 // SetFpLastVotedHeight sets the last voted height to the stored last voted height and last processed height

--- a/finality-provider/store/fpstore.go
+++ b/finality-provider/store/fpstore.go
@@ -112,6 +112,29 @@ func (s *FinalityProviderStore) SetFpStatus(btcPk *btcec.PublicKey, status proto
 	return s.setFinalityProviderState(btcPk, setFpStatus)
 }
 
+// UpdateFpStatusFromVotingPower based on the current voting power of the finality provider
+// updates the status, if it has some voting power, sets to active
+func (s *FinalityProviderStore) UpdateFpStatusFromVotingPower(
+	vp uint64,
+	fp *StoredFinalityProvider,
+) error {
+	if vp > 0 {
+		// voting power > 0 then set the status to ACTIVE
+		return s.SetFpStatus(fp.BtcPk, proto.FinalityProviderStatus_ACTIVE)
+	}
+
+	// voting power == 0 then set status depending on previous status
+	switch fp.Status {
+	case proto.FinalityProviderStatus_CREATED:
+		// previous status is CREATED then set to REGISTERED
+		return s.SetFpStatus(fp.BtcPk, proto.FinalityProviderStatus_REGISTERED)
+	case proto.FinalityProviderStatus_ACTIVE:
+		// previous status is ACTIVE then set to INACTIVE
+		return s.SetFpStatus(fp.BtcPk, proto.FinalityProviderStatus_INACTIVE)
+	}
+	return nil
+}
+
 // SetFpLastVotedHeight sets the last voted height to the stored last voted height and last processed height
 // only if it is larger than the stored one. This is to ensure the stored state to increase monotonically
 func (s *FinalityProviderStore) SetFpLastVotedHeight(btcPk *btcec.PublicKey, lastVotedHeight uint64) error {

--- a/finality-provider/store/storedfp.go
+++ b/finality-provider/store/storedfp.go
@@ -77,3 +77,14 @@ func (sfp *StoredFinalityProvider) ToFinalityProviderInfo() *proto.FinalityProvi
 		Status:          sfp.Status.String(),
 	}
 }
+
+// ShouldSyncStatusFromVotingPower returns true if it should modify the status based on the
+// blockchain data.
+func (sfp *StoredFinalityProvider) ShouldSyncStatusFromVotingPower(vp uint64) bool {
+	if vp > 0 {
+		return true
+	}
+
+	return sfp.Status == proto.FinalityProviderStatus_CREATED ||
+		sfp.Status == proto.FinalityProviderStatus_ACTIVE
+}

--- a/finality-provider/store/storedfp.go
+++ b/finality-provider/store/storedfp.go
@@ -78,8 +78,11 @@ func (sfp *StoredFinalityProvider) ToFinalityProviderInfo() *proto.FinalityProvi
 	}
 }
 
-// ShouldSyncStatusFromVotingPower returns true if it should modify the status based on the
-// blockchain data.
+// ShouldSyncStatusFromVotingPower returns true if the status should be updated
+// based on the provided voting power or the current status of the finality provider.
+//
+// It returns true if the voting power is greater than zero, or if the status
+// is either 'CREATED' or 'ACTIVE'.
 func (sfp *StoredFinalityProvider) ShouldSyncStatusFromVotingPower(vp uint64) bool {
 	if vp > 0 {
 		return true

--- a/finality-provider/store/storedfp.go
+++ b/finality-provider/store/storedfp.go
@@ -91,3 +91,16 @@ func (sfp *StoredFinalityProvider) ShouldSyncStatusFromVotingPower(vp uint64) bo
 	return sfp.Status == proto.FinalityProviderStatus_CREATED ||
 		sfp.Status == proto.FinalityProviderStatus_ACTIVE
 }
+
+// ShouldStart returns true if the finality provider should start his instance
+// based on the current status of the finality provider.
+//
+// It returns false if the status is either 'CREATED' or 'SLASHED'.
+// It returs true for all the other status.
+func (sfp *StoredFinalityProvider) ShouldStart() bool {
+	if sfp.Status == proto.FinalityProviderStatus_CREATED || sfp.Status == proto.FinalityProviderStatus_SLASHED {
+		return false
+	}
+
+	return true
+}


### PR DESCRIPTION
- Removed previous `MinutesToWaitForConsumer` added in #50 since it was not good enough to wait for the chain to be up, without starting the fpd server to receive fpd creation 
- Add new loop that verifies the FP status on chain and update it accordingly (before it was only one time at startup)
- Add check for keyring key is valid at start of `NewBabylonController` to avoid panic at `mustGetTxSigner`
