### PR TITLE
chore(e2e): parse go mod for babylond version

### DIFF
--- a/itest/container/config.go
+++ b/itest/container/config.go
@@ -1,5 +1,11 @@
 package container
 
+import (
+	"github.com/babylonlabs-io/finality-provider/testutil"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
 // ImageConfig contains all images and their respective tags
 // needed for running e2e tests.
 type ImageConfig struct {
@@ -10,13 +16,14 @@ type ImageConfig struct {
 //nolint:deadcode
 const (
 	dockerBabylondRepository = "babylonlabs/babylond"
-	dockerBabylondVersionTag = "v0.10.0"
 )
 
 // NewImageConfig returns ImageConfig needed for running e2e test.
-func NewImageConfig() ImageConfig {
+func NewImageConfig(t *testing.T) ImageConfig {
+	babylondVersion, err := testutil.GetBabylonVersion()
+	require.NoError(t, err)
 	return ImageConfig{
 		BabylonRepository: dockerBabylondRepository,
-		BabylonVersion:    dockerBabylondVersionTag,
+		BabylonVersion:    babylondVersion,
 	}
 }

--- a/itest/container/container.go
+++ b/itest/container/container.go
@@ -37,9 +37,9 @@ type Manager struct {
 
 // NewManager creates a new ContainerManager instance and initializes
 // all Docker specific utilities. Returns an error if initialization fails.
-func NewManager() (docker *Manager, err error) {
+func NewManager(t *testing.T) (docker *Manager, err error) {
 	docker = &Manager{
-		cfg:       NewImageConfig(),
+		cfg:       NewImageConfig(t),
 		resources: make(map[string]*dockertest.Resource),
 	}
 	docker.pool, err = dockertest.NewPool("")

--- a/itest/test_manager.go
+++ b/itest/test_manager.go
@@ -88,7 +88,7 @@ type TestDelegationData struct {
 }
 
 func StartManager(t *testing.T) *TestManager {
-	manager, err := container.NewManager()
+	manager, err := container.NewManager(t)
 	require.NoError(t, err)
 	testDir, err := tempDir(t, "fp-e2e-test-*")
 	require.NoError(t, err)

--- a/testutil/version.go
+++ b/testutil/version.go
@@ -1,0 +1,32 @@
+package testutil
+
+import (
+	"fmt"
+	"golang.org/x/mod/modfile"
+	"os"
+	"path/filepath"
+)
+
+// GetBabylonVersion returns babylond version from go.mod
+func GetBabylonVersion() (string, error) {
+	goModPath := filepath.Join("..", "go.mod")
+	data, err := os.ReadFile(goModPath)
+	if err != nil {
+		return "", err
+	}
+
+	// Parse the go.mod file
+	modFile, err := modfile.Parse("go.mod", data, nil)
+	if err != nil {
+		return "", err
+	}
+
+	const modName = "github.com/babylonlabs-io/babylon"
+	for _, require := range modFile.Require {
+		if require.Mod.Path == modName {
+			return require.Mod.Version, nil
+		}
+	}
+
+	return "", fmt.Errorf("module %s not found", modName)
+}


### PR DESCRIPTION
Ensures that our e2e tests version use a correct version of babylond from go.mod