### PR TITLE
chore: use 0.5.0 rc version of Babylon

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	cosmossdk.io/math v1.3.0
 	github.com/CosmWasm/wasmd v0.52.0
 	github.com/avast/retry-go/v4 v4.5.1
-	github.com/babylonlabs-io/babylon v0.9.3-0.20240923010008-a6f728b02314
+	github.com/babylonlabs-io/babylon v0.9.3-0.20240925223611-a98269d17887
 	github.com/babylonlabs-io/babylon-sdk/demo v0.0.0-20240814002132-55e711397a82
 	github.com/babylonlabs-io/finality-gadget v0.1.1
 	github.com/btcsuite/btcd v0.24.2

--- a/go.sum
+++ b/go.sum
@@ -884,6 +884,8 @@ github.com/aws/aws-sdk-go v1.44.312/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8
 github.com/aws/aws-sdk-go-v2 v0.18.0/go.mod h1:JWVYvqSMppoMJC0x5wdwiImzgXTI9FuZwxzkQq9wy+g=
 github.com/babylonlabs-io/babylon v0.9.3-0.20240923010008-a6f728b02314 h1:H52j7JtYayHZlK12VsolY938AzrVj3EWJLXHP6e1SGU=
 github.com/babylonlabs-io/babylon v0.9.3-0.20240923010008-a6f728b02314/go.mod h1:Savv0qKMqan8M8kFchXocIsLI69tPmnMOZOe//sgTFI=
+github.com/babylonlabs-io/babylon v0.9.3-0.20240925223611-a98269d17887 h1:Z5UPknFpdpWJIgy71AQfQcJACpwt0KKOiHnb2OIpKaU=
+github.com/babylonlabs-io/babylon v0.9.3-0.20240925223611-a98269d17887/go.mod h1:Savv0qKMqan8M8kFchXocIsLI69tPmnMOZOe//sgTFI=
 github.com/babylonlabs-io/babylon-sdk/demo v0.0.0-20240814002132-55e711397a82 h1:BwgtEtrrbtwQo4FEsoVqeUIHiqJr5krZt6ds3g1SM4s=
 github.com/babylonlabs-io/babylon-sdk/demo v0.0.0-20240814002132-55e711397a82/go.mod h1:QqEn1sL4RPG7DJ94XFYvuvEELml64s5XwPQpTayXJss=
 github.com/babylonlabs-io/babylon-sdk/x v0.0.0-20240814002132-55e711397a82 h1:F9U6iH+RqXo2ColXvGGByWDY0DdyAMnIgjpxQbWooiE=

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -6,7 +6,7 @@ toolchain go1.22.7
 
 require (
 	github.com/CosmWasm/wasmd v0.52.0
-	github.com/babylonlabs-io/babylon v0.9.3-0.20240923010008-a6f728b02314
+	github.com/babylonlabs-io/babylon v0.9.3-0.20240925223611-a98269d17887
 	github.com/babylonlabs-io/babylon-sdk/demo v0.0.0-20240814002132-55e711397a82
 )
 

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -854,6 +854,8 @@ github.com/aws/aws-sdk-go v1.44.312/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8
 github.com/aws/aws-sdk-go-v2 v0.18.0/go.mod h1:JWVYvqSMppoMJC0x5wdwiImzgXTI9FuZwxzkQq9wy+g=
 github.com/babylonlabs-io/babylon v0.9.3-0.20240923010008-a6f728b02314 h1:H52j7JtYayHZlK12VsolY938AzrVj3EWJLXHP6e1SGU=
 github.com/babylonlabs-io/babylon v0.9.3-0.20240923010008-a6f728b02314/go.mod h1:Savv0qKMqan8M8kFchXocIsLI69tPmnMOZOe//sgTFI=
+github.com/babylonlabs-io/babylon v0.9.3-0.20240925223611-a98269d17887 h1:Z5UPknFpdpWJIgy71AQfQcJACpwt0KKOiHnb2OIpKaU=
+github.com/babylonlabs-io/babylon v0.9.3-0.20240925223611-a98269d17887/go.mod h1:Savv0qKMqan8M8kFchXocIsLI69tPmnMOZOe//sgTFI=
 github.com/babylonlabs-io/babylon-sdk/demo v0.0.0-20240814002132-55e711397a82 h1:BwgtEtrrbtwQo4FEsoVqeUIHiqJr5krZt6ds3g1SM4s=
 github.com/babylonlabs-io/babylon-sdk/demo v0.0.0-20240814002132-55e711397a82/go.mod h1:QqEn1sL4RPG7DJ94XFYvuvEELml64s5XwPQpTayXJss=
 github.com/babylonlabs-io/babylon-sdk/x v0.0.0-20240814002132-55e711397a82 h1:F9U6iH+RqXo2ColXvGGByWDY0DdyAMnIgjpxQbWooiE=


### PR DESCRIPTION
After this PR, we can tag `euphrates-0.5.0-rc.0` for FP