### PR TITLE
fix: CI failed to run the op e2e tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Set up the devnet data
         run: make op-e2e-devnet
       - name: Run e2e OP tests
-        run: make test-e2e-op
+        run: make test-e2e-op GOFLAGS="-v"
         
   docker_pipeline:
     uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@v0.1.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,8 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: '1.22'
+      - name: Set up the devnet data
+        run: make op-e2e-devnet
       - name: Run e2e OP tests
         run: make test-e2e-op
         

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Set up the devnet data
         run: make op-e2e-devnet
       - name: Run e2e OP tests
-        run: make test-e2e-op GOFLAGS="-v"
+        run: make test-e2e-op
         
   docker_pipeline:
     uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@v0.1.0

--- a/Makefile
+++ b/Makefile
@@ -115,6 +115,10 @@ test-e2e-wasmd: clean-e2e install-babylond install-wasmd
 test-e2e-op: clean-e2e install-babylond
 	@go test -mod=readonly -timeout=25m -v $(PACKAGES_E2E_OP) -count=1 --tags=e2e_op
 
+FILTER ?= .
+test-e2e-op-filter: clean-e2e install-babylond
+	@go test -mod=readonly -timeout=25m -v $(PACKAGES_E2E_OP) -count=1 --tags=e2e_op --run ^$(FILTER)$
+
 test-e2e-op-ci: clean-e2e install-babylond
 	go test -list . ./itest/opstackl2 --tags=e2e_op | grep Test \
 	| circleci tests run --command \

--- a/Makefile
+++ b/Makefile
@@ -112,9 +112,8 @@ test-e2e-bcd: clean-e2e install-babylond install-bcd
 test-e2e-wasmd: clean-e2e install-babylond install-wasmd
 	@go test -mod=readonly -timeout=25m -v $(PACKAGES_E2E) -count=1 --tags=e2e_wasmd
 
-FILTER ?= .
 test-e2e-op: clean-e2e install-babylond
-	@go test -mod=readonly -timeout=25m -v $(PACKAGES_E2E_OP) -count=1 --tags=e2e_op --run ^$(FILTER)$
+	@go test -mod=readonly -timeout=25m -v $(PACKAGES_E2E_OP) -count=1 --tags=e2e_op
 
 test-e2e-op-ci: clean-e2e install-babylond
 	go test -list . ./itest/opstackl2 --tags=e2e_op | grep Test \

--- a/itest/opstackl2/README.md
+++ b/itest/opstackl2/README.md
@@ -11,6 +11,9 @@ Then run the following command to start the e2e tests:
 ```bash
 $ make test-e2e-op
 
+# Run all tests
+$ make test-e2e-op
+
 # Filter specific test
-$ make test-e2e-op FILTER=TestFinalityGadget
+$ make test-e2e-op-filter FILTER=TestFinalityGadget
 ```


### PR DESCRIPTION
## Summary

This PR:

* adds a step to the CI `e2e_op` job to set up the devnet data for OP e2e tests, addressing the issue where the devnet data does not exist. https://github.com/babylonlabs-io/finality-provider/pull/76#issuecomment-2382903913
* removes the FILTER to fix the  `e2e_op` job issue: "no test to run"
* adds a new make target to support for the filter

## Test Plan

To trigger the CI to check if the op e2e tests work fine.
