### PR TITLE
chore: Remove running multiple fp instances support

### DIFF
--- a/finality-provider/config/config.go
+++ b/finality-provider/config/config.go
@@ -38,7 +38,6 @@ const (
 	defaultMaxSubmissionRetries    = 20
 	defaultBitcoinNetwork          = "signet"
 	defaultDataDirname             = "data"
-	defaultMaxNumFinalityProviders = 3
 )
 
 var (
@@ -69,7 +68,6 @@ type Config struct {
 	FastSyncLimit            uint64        `long:"fastsynclimit" description:"The maximum number of blocks to catch up for each fast sync"`
 	FastSyncGap              uint64        `long:"fastsyncgap" description:"The block gap that will trigger the fast sync"`
 	EOTSManagerAddress       string        `long:"eotsmanageraddress" description:"The address of the remote EOTS manager; Empty if the EOTS manager is running locally"`
-	MaxNumFinalityProviders  uint32        `long:"maxnumfinalityproviders" description:"The maximum number of finality-provider instances running concurrently within the daemon"`
 	SyncFpStatusInterval     time.Duration `long:"syncfpstatusinterval" description:"The duration of time that it should sync FP status with the client blockchain"`
 
 	BitcoinNetwork string `long:"bitcoinnetwork" description:"Bitcoin network to run on" choise:"mainnet" choice:"regtest" choice:"testnet" choice:"simnet" choice:"signet"`
@@ -112,7 +110,6 @@ func DefaultConfigWithHome(homePath string) Config {
 		BTCNetParams:             defaultBTCNetParams,
 		EOTSManagerAddress:       defaultEOTSManagerAddress,
 		RpcListener:              DefaultRpcListener,
-		MaxNumFinalityProviders:  defaultMaxNumFinalityProviders,
 		Metrics:                  metrics.DefaultFpConfig(),
 		SyncFpStatusInterval:     defaultSyncFpStatusInterval,
 	}

--- a/finality-provider/service/app.go
+++ b/finality-provider/service/app.go
@@ -321,11 +321,9 @@ func (app *FinalityProviderApp) Stop() error {
 		app.wg.Wait()
 
 		app.logger.Debug("Stopping finality providers")
-		if app.fpManager.isStarted.Load() {
-			if err := app.fpManager.Stop(); err != nil {
-				stopErr = err
-				return
-			}
+		if err := app.fpManager.Stop(); err != nil {
+			stopErr = err
+			return
 		}
 
 		app.logger.Debug("Stopping EOTS manager")

--- a/finality-provider/service/app.go
+++ b/finality-provider/service/app.go
@@ -151,10 +151,6 @@ func (app *FinalityProviderApp) Logger() *zap.Logger {
 	return app.logger
 }
 
-func (app *FinalityProviderApp) ListFinalityProviderInstances() []*FinalityProviderInstance {
-	return app.fpManager.ListFinalityProviderInstances()
-}
-
 func (app *FinalityProviderApp) ListAllFinalityProvidersInfo() ([]*proto.FinalityProviderInfo, error) {
 	return app.fpManager.AllFinalityProviders()
 }
@@ -164,8 +160,8 @@ func (app *FinalityProviderApp) GetFinalityProviderInfo(fpPk *bbntypes.BIP340Pub
 }
 
 // GetFinalityProviderInstance returns the finality-provider instance with the given Babylon public key
-func (app *FinalityProviderApp) GetFinalityProviderInstance(fpPk *bbntypes.BIP340PubKey) (*FinalityProviderInstance, error) {
-	return app.fpManager.GetFinalityProviderInstance(fpPk)
+func (app *FinalityProviderApp) GetFinalityProviderInstance() (*FinalityProviderInstance, error) {
+	return app.fpManager.GetFinalityProviderInstance()
 }
 
 func (app *FinalityProviderApp) RegisterFinalityProvider(fpPkStr string) (*RegisterFinalityProviderResponse, error) {
@@ -220,14 +216,10 @@ func (app *FinalityProviderApp) RegisterFinalityProvider(fpPkStr string) (*Regis
 	}
 }
 
-// StartHandlingFinalityProvider starts a finality-provider instance with the given Babylon public key
+// StartHandlingFinalityProvider starts a finality provider instance with the given EOTS public key
 // Note: this should be called right after the finality-provider is registered
 func (app *FinalityProviderApp) StartHandlingFinalityProvider(fpPk *bbntypes.BIP340PubKey, passphrase string) error {
 	return app.fpManager.StartFinalityProvider(fpPk, passphrase)
-}
-
-func (app *FinalityProviderApp) StartHandlingAll() error {
-	return app.fpManager.StartAll()
 }
 
 // NOTE: this is not safe in production, so only used for testing purpose
@@ -329,9 +321,11 @@ func (app *FinalityProviderApp) Stop() error {
 		app.wg.Wait()
 
 		app.logger.Debug("Stopping finality providers")
-		if err := app.fpManager.Stop(); err != nil {
-			stopErr = err
-			return
+		if app.fpManager.isStarted.Load() {
+			if err := app.fpManager.Stop(); err != nil {
+				stopErr = err
+				return
+			}
 		}
 
 		app.logger.Debug("Stopping EOTS manager")

--- a/finality-provider/service/app_test.go
+++ b/finality-provider/service/app_test.go
@@ -133,7 +133,7 @@ func FuzzRegisterFinalityProvider(f *testing.F) {
 		err = app.StartHandlingFinalityProvider(fp.GetBIP340BTCPK(), passphrase)
 		require.NoError(t, err)
 
-		fpAfterReg, err := app.GetFinalityProviderInstance(fp.GetBIP340BTCPK())
+		fpAfterReg, err := app.GetFinalityProviderInstance()
 		require.NoError(t, err)
 		require.Equal(t, proto.FinalityProviderStatus_REGISTERED, fpAfterReg.GetStoreFinalityProvider().Status)
 
@@ -210,7 +210,7 @@ func FuzzSyncFinalityProviderStatus(f *testing.F) {
 			if noVotingPowerTable {
 				expectedStatus = proto.FinalityProviderStatus_REGISTERED
 			}
-			fpInstance, err := app.GetFinalityProviderInstance(fpPk)
+			fpInstance, err := app.GetFinalityProviderInstance()
 			if err != nil {
 				return false
 			}

--- a/finality-provider/service/fp_instance.go
+++ b/finality-provider/service/fp_instance.go
@@ -67,12 +67,11 @@ func NewFinalityProviderInstance(
 ) (*FinalityProviderInstance, error) {
 	sfp, err := s.GetFinalityProvider(fpPk.MustToBTCPK())
 	if err != nil {
-		return nil, fmt.Errorf("failed to retrive the finality-provider %s from DB: %w", fpPk.MarshalHex(), err)
+		return nil, fmt.Errorf("failed to retrive the finality provider %s from DB: %w", fpPk.MarshalHex(), err)
 	}
 
-	// ensure the finality-provider has been registered
-	if sfp.Status < proto.FinalityProviderStatus_REGISTERED {
-		return nil, fmt.Errorf("the finality-provider %s has not been registered", sfp.KeyName)
+	if !sfp.ShouldStart() {
+		return nil, fmt.Errorf("the finality provider instance cannot be initiated with status %s", sfp.Status.String())
 	}
 
 	return &FinalityProviderInstance{

--- a/finality-provider/service/fp_instance_test.go
+++ b/finality-provider/service/fp_instance_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/babylonlabs-io/babylon/testutil/datagen"
 	ftypes "github.com/babylonlabs-io/babylon/x/finality/types"
+
 	"github.com/babylonlabs-io/finality-provider/clientcontroller"
 	"github.com/babylonlabs-io/finality-provider/eotsmanager"
 	eotscfg "github.com/babylonlabs-io/finality-provider/eotsmanager/config"
@@ -119,8 +120,6 @@ func startFinalityProviderAppWithRegisteredFp(t *testing.T, r *rand.Rand, cc cli
 	app, err := service.NewFinalityProviderApp(&fpCfg, cc, em, db, logger)
 	require.NoError(t, err)
 	err = app.Start()
-	require.NoError(t, err)
-	err = app.StartHandlingAll()
 	require.NoError(t, err)
 
 	// create registered finality-provider

--- a/finality-provider/service/fp_manager_test.go
+++ b/finality-provider/service/fp_manager_test.go
@@ -76,7 +76,8 @@ func FuzzStatusUpdate(f *testing.F) {
 
 		err := vm.StartFinalityProvider(fpPk, passphrase)
 		require.NoError(t, err)
-		fpIns := vm.ListFinalityProviderInstances()[0]
+		fpIns, err := vm.GetFinalityProviderInstance()
+		require.NoError(t, err)
 		// stop the finality-provider as we are testing static functionalities
 		err = fpIns.Stop()
 		require.NoError(t, err)

--- a/finality-provider/service/rpcserver.go
+++ b/finality-provider/service/rpcserver.go
@@ -146,9 +146,15 @@ func (r *rpcServer) AddFinalitySignature(ctx context.Context, req *proto.AddFina
 		return nil, err
 	}
 
-	fpi, err := r.app.GetFinalityProviderInstance(fpPk)
+	fpi, err := r.app.GetFinalityProviderInstance()
 	if err != nil {
 		return nil, err
+	}
+
+	if fpi.GetBtcPkHex() != req.BtcPk {
+		return nil, fmt.Errorf(
+			"the finality provider running does not match the request, got: %s, expected: %s",
+			req.BtcPk, fpi.GetBtcPkHex())
 	}
 
 	b := &types.BlockInfo{

--- a/finality-provider/store/storedfp.go
+++ b/finality-provider/store/storedfp.go
@@ -81,10 +81,12 @@ func (sfp *StoredFinalityProvider) ToFinalityProviderInfo() *proto.FinalityProvi
 // ShouldStart returns true if the finality provider should start his instance
 // based on the current status of the finality provider.
 //
-// It returns false if the status is either 'CREATED' or 'SLASHED'.
+// It returns false if the status is either 'CREATED', 'JAILED' or 'SLASHED'.
 // It returs true for all the other status.
 func (sfp *StoredFinalityProvider) ShouldStart() bool {
-	if sfp.Status == proto.FinalityProviderStatus_CREATED || sfp.Status == proto.FinalityProviderStatus_SLASHED {
+	if sfp.Status == proto.FinalityProviderStatus_CREATED ||
+		sfp.Status == proto.FinalityProviderStatus_SLASHED ||
+		sfp.Status == proto.FinalityProviderStatus_JAILED {
 		return false
 	}
 

--- a/itest/e2e_test.go
+++ b/itest/e2e_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/stretchr/testify/require"
 
-	"github.com/babylonlabs-io/finality-provider/finality-provider/proto"
 	"github.com/babylonlabs-io/finality-provider/types"
 )
 
@@ -100,14 +99,9 @@ func TestDoubleSigning(t *testing.T) {
 
 	tm.WaitForFpShutDown(t)
 
-	// try to start all the finality providers and the slashed one should not be restarted
+	// try to start the finality providers and the slashed one should expect err
 	err = tm.Fpa.StartHandlingFinalityProvider(fpIns.GetBtcPkBIP340(), "")
-	require.NoError(t, err)
-	fps, err := tm.Fpa.ListAllFinalityProvidersInfo()
-	require.NoError(t, err)
-	require.Equal(t, 1, len(fps))
-	require.Equal(t, proto.FinalityProviderStatus_name[4], fps[0].Status)
-	require.Equal(t, false, fps[0].IsRunning)
+	require.Error(t, err)
 }
 
 // TestFastSync tests the fast sync process where the finality-provider is terminated and restarted with fast sync

--- a/itest/e2e_test.go
+++ b/itest/e2e_test.go
@@ -26,10 +26,8 @@ var (
 // activation with BTC delegation and Covenant sig ->
 // vote submission -> block finalization
 func TestFinalityProviderLifeCycle(t *testing.T) {
-	tm, fpInsList := StartManagerWithFinalityProvider(t, 1)
+	tm, fpIns := StartManagerWithFinalityProvider(t)
 	defer tm.Stop(t)
-
-	fpIns := fpInsList[0]
 
 	// check the public randomness is committed
 	tm.WaitForFpPubRandTimestamped(t, fpIns)
@@ -58,10 +56,8 @@ func TestFinalityProviderLifeCycle(t *testing.T) {
 // sends a finality vote over a conflicting block
 // in this case, the BTC private key should be extracted by Babylon
 func TestDoubleSigning(t *testing.T) {
-	tm, fpInsList := StartManagerWithFinalityProvider(t, 1)
+	tm, fpIns := StartManagerWithFinalityProvider(t)
 	defer tm.Stop(t)
-
-	fpIns := fpInsList[0]
 
 	// check the public randomness is committed
 	tm.WaitForFpPubRandTimestamped(t, fpIns)
@@ -102,10 +98,10 @@ func TestDoubleSigning(t *testing.T) {
 
 	t.Logf("the equivocation attack is successful")
 
-	tm.WaitForFpShutDown(t, fpIns.GetBtcPkBIP340())
+	tm.WaitForFpShutDown(t)
 
 	// try to start all the finality providers and the slashed one should not be restarted
-	err = tm.Fpa.StartHandlingAll()
+	err = tm.Fpa.StartHandlingFinalityProvider(fpIns.GetBtcPkBIP340(), "")
 	require.NoError(t, err)
 	fps, err := tm.Fpa.ListAllFinalityProvidersInfo()
 	require.NoError(t, err)
@@ -116,10 +112,8 @@ func TestDoubleSigning(t *testing.T) {
 
 // TestFastSync tests the fast sync process where the finality-provider is terminated and restarted with fast sync
 func TestFastSync(t *testing.T) {
-	tm, fpInsList := StartManagerWithFinalityProvider(t, 1)
+	tm, fpIns := StartManagerWithFinalityProvider(t)
 	defer tm.Stop(t)
-
-	fpIns := fpInsList[0]
 
 	// check the public randomness is committed
 	tm.WaitForFpPubRandTimestamped(t, fpIns)

--- a/itest/test_manager.go
+++ b/itest/test_manager.go
@@ -252,9 +252,7 @@ func StartManagerWithFinalityProvider(t *testing.T) (*TestManager, *service.Fina
 }
 
 func (tm *TestManager) Stop(t *testing.T) {
-	err := tm.Fpa.Stop()
-	require.NoError(t, err)
-	err = tm.manager.ClearResources()
+	err := tm.manager.ClearResources()
 	require.NoError(t, err)
 	err = os.RemoveAll(tm.baseDir)
 	require.NoError(t, err)

--- a/itest/test_manager.go
+++ b/itest/test_manager.go
@@ -252,7 +252,9 @@ func StartManagerWithFinalityProvider(t *testing.T) (*TestManager, *service.Fina
 }
 
 func (tm *TestManager) Stop(t *testing.T) {
-	err := tm.manager.ClearResources()
+	err := tm.Fpa.Stop()
+	require.NoError(t, err)
+	err = tm.manager.ClearResources()
 	require.NoError(t, err)
 	err = os.RemoveAll(tm.baseDir)
 	require.NoError(t, err)


### PR DESCRIPTION
This PR partly addresses https://github.com/babylonlabs-io/finality-provider/issues/34 by disallowing running multiple fp instances within the fp manager. Keyring level improvement will be done in a separate PR to address #63. Notable changes in this PR:

1. Remove `MaxNumFinalityProviders` from config as it is not applicable
2. If `--eots-pk` is not specified in `fpd start`, fp app will start without any fp instances. To run a fp instance, `--eots-pk` must be given
3. fp manager only keeps a single fp instance instead of a map