### PR TITLE
ci: add goreleaser setup and move out changelog reminder

### DIFF
--- a/.github/workflows/changelog-reminder.yml
+++ b/.github/workflows/changelog-reminder.yml
@@ -1,0 +1,11 @@
+name: Changelog Reminder
+on:
+  pull_request:
+    types: [assigned, opened, synchronize, reopened, labeled, unlabeled]
+    branches:
+      - main
+
+jobs:
+  changelog_reminder:
+    uses: babylonlabs-io/.github/.github/workflows/reusable_changelog_reminder.yml@v0.7.0
+    secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,6 @@ jobs:
       run-gosec: true
       gosec-args: "-exclude-generated -exclude-dir=itest -exclude-dir=testutil ./..."
 
-  changelog_reminder:
-    uses: babylonlabs-io/.github/.github/workflows/reusable_changelog_reminder.yml@v0.7.0
-    secrets: inherit
-
   docker_pipeline:
     uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@v0.7.0
     secrets: inherit

--- a/.gitignore
+++ b/.gitignore
@@ -26,5 +26,6 @@
 main
 tmp/
 build/
+dist/
 
 *.swp

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -52,14 +52,16 @@ builds:
 archives:
   - id: zipped
     builds:
-      - finality-provider-linux-amd64
+      - fpd-linux-amd64
+      - eotsd-linux-amd64
     name_template: "{{.ProjectName}}-{{ .Version }}-{{ .Os }}-{{ .Arch }}"
     format: tar.gz
     files:
       - none*
   - id: binaries
     builds:
-      - finality-provider-linux-amd64
+      - fpd-linux-amd64
+      - eotsd-linux-amd64
     name_template: "{{.ProjectName}}-{{ .Version }}-{{ .Os }}-{{ .Arch }}"
     format: binary
     files:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,11 +16,6 @@ builds:
     flags:
       - -mod=readonly
       - -trimpath
-    ldflags:
-      - -X github.com/babylonlabs-io/finality-provider/version.Name=finality-provider
-      - -X github.com/babylonlabs-io/finality-provider/version.Version={{ .Version }}
-      - -X github.com/babylonlabs-io/finality-provider/version.Commit={{ .Commit }}
-      - -w -s
     tags:
       - netgo
       - osusergo
@@ -40,11 +35,6 @@ builds:
     flags:
       - -mod=readonly
       - -trimpath
-    ldflags:
-      - -X github.com/babylonlabs-io/finality-provider/version.Name=finality-provider
-      - -X github.com/babylonlabs-io/finality-provider/version.Version={{ .Version }}
-      - -X github.com/babylonlabs-io/finality-provider/version.Commit={{ .Commit }}
-      - -w -s
     tags:
       - netgo
       - osusergo

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,81 @@
+project_name: finality-provider
+
+builds:
+  - id: fpd-linux-amd64
+    main: ./finality-provider/cmd/fpd/main.go
+    binary: fpd
+    hooks:
+      pre:
+        - wget https://github.com/CosmWasm/wasmvm/releases/download/{{ .Env.COSMWASM_VERSION }}/libwasmvm_muslc.x86_64.a -O /usr/lib/libwasmvm_muslc.x86_64.a
+    goos:
+      - linux
+    goarch:
+      - amd64
+    env:
+      - GO111MODULE=on
+    flags:
+      - -mod=readonly
+      - -trimpath
+    ldflags:
+      - -X github.com/babylonlabs-io/finality-provider/version.Name=finality-provider
+      - -X github.com/babylonlabs-io/finality-provider/version.Version={{ .Version }}
+      - -X github.com/babylonlabs-io/finality-provider/version.Commit={{ .Commit }}
+      - -w -s
+    tags:
+      - netgo
+      - osusergo
+
+  - id: eotsd-linux-amd64
+    main: ./eotsmanager/cmd/eotsd/main.go
+    binary: eotsd
+    hooks:
+      pre:
+        - wget https://github.com/CosmWasm/wasmvm/releases/download/{{ .Env.COSMWASM_VERSION }}/libwasmvm_muslc.x86_64.a -O /usr/lib/libwasmvm_muslc.x86_64.a
+    goos:
+      - linux
+    goarch:
+      - amd64
+    env:
+      - GO111MODULE=on
+    flags:
+      - -mod=readonly
+      - -trimpath
+    ldflags:
+      - -X github.com/babylonlabs-io/finality-provider/version.Name=finality-provider
+      - -X github.com/babylonlabs-io/finality-provider/version.Version={{ .Version }}
+      - -X github.com/babylonlabs-io/finality-provider/version.Commit={{ .Commit }}
+      - -w -s
+    tags:
+      - netgo
+      - osusergo
+
+archives:
+  - id: zipped
+    builds:
+      - finality-provider-linux-amd64
+    name_template: "{{.ProjectName}}-{{ .Version }}-{{ .Os }}-{{ .Arch }}"
+    format: tar.gz
+    files:
+      - none*
+  - id: binaries
+    builds:
+      - finality-provider-linux-amd64
+    name_template: "{{.ProjectName}}-{{ .Version }}-{{ .Os }}-{{ .Arch }}"
+    format: binary
+    files:
+      - none*
+
+checksum:
+  name_template: "{{ .ProjectName }}_{{ .Version }}_checksums.txt"
+  algorithm: sha256
+
+release:
+  github:
+    owner: babylonlabs-io
+    name: finality-provider
+
+# Docs: https://goreleaser.com/customization/changelog/
+changelog:
+  disable: true
+
+dist: dist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,3 +36,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## Unreleased
+
+### Misc Improvements
+
+* [#91](https://github.com/babylonlabs-io/finality-provider/pull/91) Go releaser setup
+  and move changelog reminder out

--- a/Makefile
+++ b/Makefile
@@ -84,3 +84,58 @@ update-changelog:
 	./scripts/update_changelog.sh $(sinceTag) $(upcomingTag)
 
 .PHONY: update-changelog
+
+###############################################################################
+###                                Release                                  ###
+###############################################################################
+
+# The below is adapted from https://github.com/osmosis-labs/osmosis/blob/main/Makefile
+GO_VERSION := $(shell grep -E '^go [0-9]+\.[0-9]+' go.mod | awk '{print $$2}')
+GORELEASER_IMAGE := ghcr.io/goreleaser/goreleaser-cross:v$(GO_VERSION)
+COSMWASM_VERSION := $(shell go list -m github.com/CosmWasm/wasmvm/v2 | sed 's/.* //')
+
+.PHONY: release-dry-run release-snapshot release
+release-dry-run:
+	docker run \
+		--rm \
+		-e COSMWASM_VERSION=$(COSMWASM_VERSION) \
+		-v /var/run/docker.sock:/var/run/docker.sock \
+		-v `pwd`:/go/src/babylon \
+		-w /go/src/babylon \
+		$(GORELEASER_IMAGE) \
+		release \
+		--clean \
+		--skip-publish
+
+release-snapshot:
+	docker run \
+		--rm \
+		-e COSMWASM_VERSION=$(COSMWASM_VERSION) \
+		-v /var/run/docker.sock:/var/run/docker.sock \
+		-v `pwd`:/go/src/babylon \
+		-w /go/src/babylon \
+		$(GORELEASER_IMAGE) \
+		release \
+		--clean \
+		--snapshot \
+		--skip-validate \
+		--skip-publish
+
+# NOTE: By default, the CI will handle the release process.
+# this is for manually releasing.
+ifdef GITHUB_TOKEN
+release:
+	docker run \
+		--rm \
+		-e GITHUB_TOKEN=$(GITHUB_TOKEN) \
+		-e COSMWASM_VERSION=$(COSMWASM_VERSION) \
+		-v /var/run/docker.sock:/var/run/docker.sock \
+		-v `pwd`:/go/src/babylon \
+		-w /go/src/babylon \
+		$(GORELEASER_IMAGE) \
+		release \
+		--clean
+else
+release:
+	@echo "Error: GITHUB_TOKEN is not defined. Please define it before running 'make release'."
+endif

--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ release-dry-run:
 		$(GORELEASER_IMAGE) \
 		release \
 		--clean \
-		--skip-publish
+		--skip=publish
 
 release-snapshot:
 	docker run \
@@ -118,8 +118,7 @@ release-snapshot:
 		release \
 		--clean \
 		--snapshot \
-		--skip-validate \
-		--skip-publish
+		--skip=publish,validate \
 
 # NOTE: By default, the CI will handle the release process.
 # this is for manually releasing.


### PR DESCRIPTION
This PR

- sets up Go releaser for Babylon. Currently it only supports linux amd64. Other targets will be supported in the future. To test locally, run `make release-snapshot`
- moves changelog reminder out from the CI flow