### PR TITLE
fix: remove the url check for fg rpc

### DIFF
--- a/finality-provider/config/opstackl2.go
+++ b/finality-provider/config/opstackl2.go
@@ -46,9 +46,6 @@ func (cfg *OPStackL2Config) Validate() error {
 	if cfg.BabylonFinalityGadgetRpc == "" {
 		return fmt.Errorf("babylon-finality-gadget-rpc is required")
 	}
-	if _, err := url.Parse(cfg.BabylonFinalityGadgetRpc); err != nil {
-		return fmt.Errorf("babylon-finality-gadget-rpc is not correctly formatted: %w", err)
-	}
 	if _, err := url.Parse(cfg.RPCAddr); err != nil {
 		return fmt.Errorf("rpc-addr is not correctly formatted: %w", err)
 	}


### PR DESCRIPTION
## Summary

The finality gadget is a gRPC service, its rpc should be a host or ip:port without the `scheme://`, so we can't use `url.Parse` to validate it.

## Test Plan

FP should be launched with the `BabylonFinalityGadgetRpc=135.225.83.181:50051` 