### PR TITLE
refactor: add a interface for chain poller

### DIFF
--- a/clientcontroller/api/interface.go
+++ b/clientcontroller/api/interface.go
@@ -71,3 +71,24 @@ type ConsumerController interface {
 
 	Close() error
 }
+
+// ChainPoller is a interface that got block info from the consumer chain.
+type ConsumerChainPoller interface {
+	// Start the poller, will begin with the `startHeight`
+	Start(startHeight uint64) error
+
+	// SkipToHeight make poller skip blocks in `GetBlockInfoChan` until the `height`.
+	SkipToHeight(height uint64) error
+
+	// Return read only channel for incoming blocks
+	// TODO: Handle the case when there is more than one consumer. Currently with more than
+	// one consumer blocks most probably will be received out of order to those consumers.
+	GetBlockInfoChan() <-chan *types.BlockInfo
+
+	Stop() error
+}
+
+// ConsumerChainPollerFactory is a factory for creating chain pollers by fp manager
+type ConsumerChainPollerFactory interface {
+	CreateChainPoller() (ConsumerChainPoller, error)
+}

--- a/finality-provider/service/chain_poller.go
+++ b/finality-provider/service/chain_poller.go
@@ -37,6 +37,36 @@ type skipHeightResponse struct {
 	err error
 }
 
+type ChainPollerFactory struct {
+	logger      *zap.Logger
+	cfg         *cfg.ChainPollerConfig
+	cc          ccapi.ClientController
+	consumerCon ccapi.ConsumerController
+	metrics     *metrics.FpMetrics
+}
+
+var _ ccapi.ConsumerChainPollerFactory = &ChainPollerFactory{}
+
+func NewChainPollerFactory(
+	logger *zap.Logger,
+	cfg *cfg.ChainPollerConfig,
+	cc ccapi.ClientController,
+	consumerCon ccapi.ConsumerController,
+	metrics *metrics.FpMetrics,
+) *ChainPollerFactory {
+	return &ChainPollerFactory{
+		logger:      logger,
+		cfg:         cfg,
+		cc:          cc,
+		consumerCon: consumerCon,
+		metrics:     metrics,
+	}
+}
+
+func (f *ChainPollerFactory) CreateChainPoller() (ccapi.ConsumerChainPoller, error) {
+	return NewChainPoller(f.logger, f.cfg, f.cc, f.consumerCon, f.metrics), nil
+}
+
 type ChainPoller struct {
 	isStarted *atomic.Bool
 	wg        sync.WaitGroup
@@ -51,6 +81,8 @@ type ChainPoller struct {
 	nextHeight     uint64
 	logger         *zap.Logger
 }
+
+var _ ccapi.ConsumerChainPoller = &ChainPoller{}
 
 func NewChainPoller(
 	logger *zap.Logger,

--- a/finality-provider/service/fp_manager_test.go
+++ b/finality-provider/service/fp_manager_test.go
@@ -135,7 +135,9 @@ func newFinalityProviderManagerWithRegisteredFp(t *testing.T, r *rand.Rand, cc c
 	require.NoError(t, err)
 
 	metricsCollectors := metrics.NewFpMetrics()
-	vm, err := service.NewFinalityProviderManager(fpStore, pubRandStore, &fpCfg, cc, consumerCon, em, metricsCollectors, logger)
+	pollerFactory := service.NewChainPollerFactory(logger, fpCfg.PollerConfig, cc, consumerCon, metricsCollectors)
+
+	vm, err := service.NewFinalityProviderManager(fpStore, pubRandStore, &fpCfg, cc, consumerCon, pollerFactory, em, metricsCollectors, logger)
 	require.NoError(t, err)
 
 	// create registered finality-provider

--- a/itest/babylon/babylon_test_manager.go
+++ b/itest/babylon/babylon_test_manager.go
@@ -14,6 +14,7 @@ import (
 	"github.com/babylonlabs-io/finality-provider/clientcontroller"
 	e2eutils "github.com/babylonlabs-io/finality-provider/itest"
 	base_test_manager "github.com/babylonlabs-io/finality-provider/itest/test-manager"
+	"github.com/babylonlabs-io/finality-provider/metrics"
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -79,8 +80,12 @@ func StartManager(t *testing.T) *TestManager {
 	// 4. prepare finality-provider
 	fpdb, err := cfg.DatabaseConfig.GetDbBackend()
 	require.NoError(t, err)
-	fpApp, err := service.NewFinalityProviderApp(cfg, bc, bcc, eotsCli, fpdb, logger)
+
+	fpMetrics := metrics.NewFpMetrics()
+	pollerFactory := service.NewChainPollerFactory(logger, cfg.PollerConfig, bc, bcc, fpMetrics)
+	fpApp, err := service.NewFinalityProviderApp(cfg, bc, bcc, pollerFactory, eotsCli, fpdb, fpMetrics, logger)
 	require.NoError(t, err)
+
 	err = fpApp.Start()
 	require.NoError(t, err)
 

--- a/itest/cosmwasm/wasmd/wasmd_test_manager.go
+++ b/itest/cosmwasm/wasmd/wasmd_test_manager.go
@@ -23,6 +23,7 @@ import (
 	fpcfg "github.com/babylonlabs-io/finality-provider/finality-provider/config"
 	"github.com/babylonlabs-io/finality-provider/finality-provider/service"
 	e2eutils "github.com/babylonlabs-io/finality-provider/itest"
+	"github.com/babylonlabs-io/finality-provider/metrics"
 	"github.com/babylonlabs-io/finality-provider/types"
 	"github.com/btcsuite/btcd/btcec/v2"
 	dbm "github.com/cosmos/cosmos-db"
@@ -107,7 +108,10 @@ func StartWasmdTestManager(t *testing.T) *WasmdTestManager {
 	// 5. prepare finality-provider
 	fpdb, err := cfg.DatabaseConfig.GetDbBackend()
 	require.NoError(t, err)
-	fpApp, err := service.NewFinalityProviderApp(cfg, bc, wcc, eotsCli, fpdb, logger)
+
+	fpMetrics := metrics.NewFpMetrics()
+	pollerFactory := service.NewChainPollerFactory(logger, cfg.PollerConfig, bc, wcc, fpMetrics)
+	fpApp, err := service.NewFinalityProviderApp(cfg, bc, wcc, pollerFactory, eotsCli, fpdb, fpMetrics, logger)
 	require.NoError(t, err)
 	err = fpApp.Start()
 	require.NoError(t, err)


### PR DESCRIPTION
In currently, the finality provider 's manger and instance use a fixed chain poller to fetch block infos from consumer chain, but for different consumer chain, the poller 's implment maybe very different.

Now the `ChainPoller` struct can work well for eth layer2 or op based layer2, but can not support other layer2 like orbit or zksync, so if we make a service to support orbit based consumer chain, we can not reuse the finality-provider 's code.

So we add a interface for chain poller, it can allow other service implment it 's spec poller for other chain. because the manager will create instance in runtime, so we add a chain poller factory interface as a creator.

TODO: in future we can add a mock for chain poller to test some case like consumer chain block reorg.