### PR TITLE
[RFC] feat: add new cmd `fpd commit-pubrand [fp-eots-pk-hex] [block-height]`

### DIFF
--- a/finality-provider/cmd/fpd/daemon/commit_pr.go
+++ b/finality-provider/cmd/fpd/daemon/commit_pr.go
@@ -54,7 +54,6 @@ func runCommandCommitPubRand(ctx client.Context, cmd *cobra.Command, args []stri
 
 	// override to control the exact block height to commit to
 	cfg.MinRandHeightGap = 0
-	prCommitInterval := cfg.RandomnessCommitInterval
 
 	logger, err := log.NewRootLoggerWithFile(fpcfg.LogFile(homePath), cfg.LogLevel)
 	if err != nil {
@@ -76,7 +75,7 @@ func runCommandCommitPubRand(ctx client.Context, cmd *cobra.Command, args []stri
 		return fmt.Errorf("failed to get finality provider instance: %w", err)
 	}
 
-	return commitUntilHeight(fp, blkHeight, prCommitInterval)
+	return commitUntilHeight(fp, blkHeight, cfg.RandomnessCommitInterval)
 }
 
 func commitUntilHeight(

--- a/finality-provider/cmd/fpd/daemon/commit_pr.go
+++ b/finality-provider/cmd/fpd/daemon/commit_pr.go
@@ -1,0 +1,108 @@
+package daemon
+
+import (
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"time"
+
+	bbntypes "github.com/babylonlabs-io/babylon/types"
+	fpcmd "github.com/babylonlabs-io/finality-provider/finality-provider/cmd"
+	fpcfg "github.com/babylonlabs-io/finality-provider/finality-provider/config"
+	"github.com/babylonlabs-io/finality-provider/finality-provider/service"
+	"github.com/babylonlabs-io/finality-provider/log"
+	"github.com/babylonlabs-io/finality-provider/util"
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/spf13/cobra"
+)
+
+// CommandCommitPubRand returns the commit-pubrand command by connecting to the fpd daemon.
+func CommandCommitPubRand() *cobra.Command {
+	var cmd = &cobra.Command{
+		Use:     "commit-pubrand [fp-eots-pk-hex] [block-height]",
+		Aliases: []string{"cpr"},
+		Short:   "Manually trigger public randomness commitment for a finality provider",
+		Example: `fpd commit-pubrand --home /home/user/.fpd [fp-eots-pk-hex] [block-height]`,
+		Args:    cobra.ExactArgs(2),
+		RunE:    fpcmd.RunEWithClientCtx(runCommandCommitPubRand),
+	}
+	return cmd
+}
+
+func runCommandCommitPubRand(ctx client.Context, cmd *cobra.Command, args []string) error {
+	fpPk, err := bbntypes.NewBIP340PubKeyFromHex(args[0])
+	if err != nil {
+		return err
+	}
+	blkHeight, err := strconv.ParseUint(args[1], 10, 64)
+	if err != nil {
+		return err
+	}
+
+	// Get homePath from context like in start.go
+	clientCtx := client.GetClientContextFromCmd(cmd)
+	homePath, err := filepath.Abs(clientCtx.HomeDir)
+	if err != nil {
+		return err
+	}
+	homePath = util.CleanAndExpandPath(homePath)
+
+	cfg, err := fpcfg.LoadConfig(homePath)
+	if err != nil {
+		return fmt.Errorf("failed to load configuration: %w", err)
+	}
+
+	// override to control the exact block height to commit to
+	cfg.MinRandHeightGap = 0
+	prCommitInterval := cfg.RandomnessCommitInterval
+
+	logger, err := log.NewRootLoggerWithFile(fpcfg.LogFile(homePath), cfg.LogLevel)
+	if err != nil {
+		return fmt.Errorf("failed to initialize the logger: %w", err)
+	}
+
+	dbBackend, err := cfg.DatabaseConfig.GetDbBackend()
+	if err != nil {
+		return fmt.Errorf("failed to create db backend: %w", err)
+	}
+
+	fpApp, err := service.NewFinalityProviderAppFromConfig(cfg, dbBackend, logger)
+	if err != nil {
+		return fmt.Errorf("failed to create finality-provider app: %w", err)
+	}
+
+	fp, err := fpApp.GetFinalityProviderInstance(fpPk)
+	if err != nil {
+		return fmt.Errorf("failed to get finality provider instance: %w", err)
+	}
+
+	return commitUntilHeight(fp, blkHeight, prCommitInterval)
+}
+
+func commitUntilHeight(
+	fp *service.FinalityProviderInstance,
+	blkHeight uint64,
+	interval time.Duration,
+) error {
+	commitRandTicker := time.NewTicker(interval)
+	defer commitRandTicker.Stop()
+
+	lastCommittedHeight, err := fp.GetLastCommittedHeight()
+	if err != nil {
+		return fmt.Errorf("failed to get last committed height: %w", err)
+	}
+
+	for lastCommittedHeight < blkHeight {
+		<-commitRandTicker.C
+		_, err = fp.CommitPubRand(blkHeight)
+		if err != nil {
+			return fmt.Errorf("failed to commit public randomness: %w", err)
+		}
+
+		lastCommittedHeight, err = fp.GetLastCommittedHeight()
+		if err != nil {
+			return fmt.Errorf("failed to get last committed height: %w", err)
+		}
+	}
+	return nil
+}

--- a/finality-provider/cmd/fpd/main.go
+++ b/finality-provider/cmd/fpd/main.go
@@ -34,6 +34,7 @@ func main() {
 		daemon.CommandGetDaemonInfo(), daemon.CommandCreateFP(), daemon.CommandLsFP(),
 		daemon.CommandInfoFP(), daemon.CommandRegisterFP(), daemon.CommandAddFinalitySig(),
 		daemon.CommandExportFP(), daemon.CommandTxs(),
+		daemon.CommandCommitPubRand(),
 	)
 
 	if err := cmd.Execute(); err != nil {

--- a/finality-provider/service/fp_instance.go
+++ b/finality-provider/service/fp_instance.go
@@ -669,6 +669,7 @@ func (fp *FinalityProviderInstance) retryCommitPubRandUntilMaxRetry(targetBlockH
 // CommitPubRand generates a list of Schnorr rand pairs,
 // commits the public randomness for the managed finality providers,
 // and save the randomness pair to DB
+// Note: if the targetBlockHeight is too large, it will only commit fp.cfg.NumPubRand pairs
 func (fp *FinalityProviderInstance) CommitPubRand(targetBlockHeight uint64) (*types.TxResponse, error) {
 	lastCommittedHeight, err := fp.GetLastCommittedHeight()
 	if err != nil {


### PR DESCRIPTION
## Summary

https://github.com/babylonlabs-io/finality-provider/issues/115

At `bootstrap()`, FP will fast sync to try to fast sync to the latest block. however, this makes a false assumption that PR is always ready.

So if the PR is lagging behind, fast sync will always fail b/c we never fast sync PRs. Then `bootstrap()` will stuck forever.

There are a few scenarios that can lead to this situation (we met with most of them):
- FP run out of BBN for a long time
- L2 RPC is down for a long time
- FP is down for a long time
- Babylon RPC is down for a long time

A proper fix is to remove fast sync from the `bootstrap()` step but that needs a massive refactor. As we discussed, we will use batch processing and get rid of fast sync completely.

For now, this helper command will help us recover FPs that are stuck at bootstrap.

## TODOs

I am sending this out for comments first. after discussion, I will do the following:

- add automated tests
- e2e test manually
- add the same changes in the `main` branch