### PR TITLE
fix: Voting power query error handler for consumer chain

### DIFF
--- a/clientcontroller/babylon/babylon.go
+++ b/clientcontroller/babylon/babylon.go
@@ -166,7 +166,7 @@ func (bc *BabylonController) QueryFinalityProviderHasPower(fpPk *btcec.PublicKey
 		// therefore, it should be treated as the fp having 0 voting power
 		if strings.Contains(err.Error(), btcstakingtypes.ErrVotingPowerTableNotUpdated.Error()) {
 			bc.logger.Info("the voting power table not updated yet")
-			return true, nil
+			return false, nil
 		}
 
 		return false, fmt.Errorf("failed to query Finality Voting Power at Height %d: %w", blockHeight, err)

--- a/itest/opstackl2/op_test_manager.go
+++ b/itest/opstackl2/op_test_manager.go
@@ -20,7 +20,17 @@ import (
 	"github.com/babylonlabs-io/finality-gadget/db"
 	"github.com/babylonlabs-io/finality-gadget/finalitygadget"
 	fgsrv "github.com/babylonlabs-io/finality-gadget/server"
-	api "github.com/babylonlabs-io/finality-provider/clientcontroller/api"
+	"github.com/btcsuite/btcd/btcec/v2"
+	sdkquerytypes "github.com/cosmos/cosmos-sdk/types/query"
+	ope2e "github.com/ethereum-optimism/optimism/op-e2e"
+	optestlog "github.com/ethereum-optimism/optimism/op-service/testlog"
+	gethlog "github.com/ethereum/go-ethereum/log"
+	"github.com/lightningnetwork/lnd/signal"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+
+	"github.com/babylonlabs-io/finality-provider/clientcontroller/api"
 	bbncc "github.com/babylonlabs-io/finality-provider/clientcontroller/babylon"
 	"github.com/babylonlabs-io/finality-provider/clientcontroller/opstackl2"
 	opcc "github.com/babylonlabs-io/finality-provider/clientcontroller/opstackl2"
@@ -33,15 +43,6 @@ import (
 	"github.com/babylonlabs-io/finality-provider/metrics"
 	"github.com/babylonlabs-io/finality-provider/testutil/log"
 	"github.com/babylonlabs-io/finality-provider/types"
-	"github.com/btcsuite/btcd/btcec/v2"
-	sdkquerytypes "github.com/cosmos/cosmos-sdk/types/query"
-	ope2e "github.com/ethereum-optimism/optimism/op-e2e"
-	optestlog "github.com/ethereum-optimism/optimism/op-service/testlog"
-	gethlog "github.com/ethereum/go-ethereum/log"
-	"github.com/lightningnetwork/lnd/signal"
-	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 )
 
 const (
@@ -354,7 +355,7 @@ func createBaseFpConfig(fpHomeDir string, index int, logger *zap.Logger) *fpcfg.
 	cfg.LogLevel = logger.Level().String()
 	cfg.StatusUpdateInterval = 2 * time.Second
 	cfg.RandomnessCommitInterval = 2 * time.Second
-	cfg.NumPubRand = 64
+	cfg.NumPubRand = 100
 	cfg.MinRandHeightGap = 1000
 	cfg.FastSyncGap = 60
 	cfg.FastSyncLimit = 100


### PR DESCRIPTION
The previous fix #142 only fixed the error handler for babylon controller chain other than the cosumer chain. This PR addressed it.