### PR TITLE
fix: Remove start height validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 empty HD path to derive new key and use master private key.
 * [#154](https://github.com/babylonlabs-io/finality-provider/pull/154) Use sign schnorr instead of getting private key from EOTS manager
 
+### Bug Fixes
+
+* [#158](https://github.com/babylonlabs-io/finality-provider/pull/158) Remove start height validation
+
 ## v0.12.0
 
 ### Bug Fixes

--- a/finality-provider/service/chain_poller.go
+++ b/finality-provider/service/chain_poller.go
@@ -117,31 +117,6 @@ func (cp *ChainPoller) GetBlockInfoChan() <-chan *types.BlockInfo {
 	return cp.blockInfoChan
 }
 
-func (cp *ChainPoller) latestBlockWithRetry() (*types.BlockInfo, error) {
-	var (
-		latestBlock *types.BlockInfo
-		err         error
-	)
-
-	if err := retry.Do(func() error {
-		latestBlock, err = cp.cc.QueryBestBlock()
-		if err != nil {
-			return err
-		}
-		return nil
-	}, RtyAtt, RtyDel, RtyErr, retry.OnRetry(func(n uint, err error) {
-		cp.logger.Debug(
-			"failed to query the consumer chain for the latest block",
-			zap.Uint("attempt", n+1),
-			zap.Uint("max_attempts", RtyAttNum),
-			zap.Error(err),
-		)
-	})); err != nil {
-		return nil, err
-	}
-	return latestBlock, nil
-}
-
 func (cp *ChainPoller) blockWithRetry(height uint64) (*types.BlockInfo, error) {
 	var (
 		block *types.BlockInfo
@@ -166,34 +141,6 @@ func (cp *ChainPoller) blockWithRetry(height uint64) (*types.BlockInfo, error) {
 	}
 
 	return block, nil
-}
-
-func (cp *ChainPoller) validateStartHeight(startHeight uint64) error {
-	// Infinite retry to get initial latest height
-	// TODO: Add possible cancellation or timeout for starting node
-
-	if startHeight == 0 {
-		return fmt.Errorf("start height can't be 0")
-	}
-
-	var currentBestChainHeight uint64
-	for {
-		lastestBlock, err := cp.latestBlockWithRetry()
-		if err != nil {
-			cp.logger.Debug("failed to query babylon for the latest status", zap.Error(err))
-			continue
-		}
-
-		currentBestChainHeight = lastestBlock.Height
-		break
-	}
-
-	// Allow the start height to be the next chain height
-	if startHeight > currentBestChainHeight+1 {
-		return fmt.Errorf("start height %d is more than the next chain tip height %d", startHeight, currentBestChainHeight+1)
-	}
-
-	return nil
 }
 
 // waitForActivation waits until BTC staking is activated

--- a/finality-provider/service/chain_poller.go
+++ b/finality-provider/service/chain_poller.go
@@ -76,11 +76,6 @@ func (cp *ChainPoller) Start(startHeight uint64) error {
 
 	cp.logger.Info("starting the chain poller")
 
-	err := cp.validateStartHeight(startHeight)
-	if err != nil {
-		return fmt.Errorf("invalid starting height %d: %w", startHeight, err)
-	}
-
 	cp.nextHeight = startHeight
 
 	cp.wg.Add(1)


### PR DESCRIPTION
Closes #157 by removing the validation that the start height should be higher than the current tip height of the consumer chain.

The validation can be removed as the poller will start until btc staking starts (at least one finality provider has voting power)