### PR TITLE
[backport] fix: Remove start height validation (#158)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## Unreleased
 
+### Bug Fixes
+
+* [#158](https://github.com/babylonlabs-io/finality-provider/pull/158) Remove start height validation
+
 ## v0.12.0
 
 ### Bug Fixes


### PR DESCRIPTION
Closes #157 by removing the validation that the start height should be higher than the current tip height of the consumer chain.

The validation can be removed as the poller will start until btc staking starts (at least one finality provider has voting power)