### PR TITLE
chore: Remove key creation in `create-finality-provider`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 empty HD path to derive new key and use master private key.
 * [#154](https://github.com/babylonlabs-io/finality-provider/pull/154) Use sign schnorr instead of getting private key from EOTS manager
 * [#167](https://github.com/babylonlabs-io/finality-provider/pull/167) Remove last processed height
+* [#168](https://github.com/babylonlabs-io/finality-provider/pull/168) Remove key creation in `create-finality-provider`
 
 ### v0.12.1
 

--- a/finality-provider/cmd/fpd/daemon/daemon_commands.go
+++ b/finality-provider/cmd/fpd/daemon/daemon_commands.go
@@ -74,9 +74,8 @@ func CommandCreateFP() *cobra.Command {
 		Use:     "create-finality-provider",
 		Aliases: []string{"cfp"},
 		Short:   "Create a finality provider object and save it in database.",
-		Long: fmt.Sprintf(`
-		Create a new finality provider object and store it in the finality provider database.
-		It needs to have an operating EOTS manager available and running.`),
+		Long: "Create a new finality provider object and store it in the finality provider database. " +
+			"It needs to have an operating EOTS manager available and running.",
 		Example: fmt.Sprintf(`fpd create-finality-provider --daemon-address %s ...`, defaultFpdDaemonAddress),
 		Args:    cobra.NoArgs,
 		RunE:    fpcmd.RunEWithClientCtx(runCommandCreateFP),
@@ -179,6 +178,10 @@ func runCommandCreateFP(ctx client.Context, cmd *cobra.Command, _ []string) erro
 	eotsPkHex, err := flags.GetString(fpEotsPkFlag)
 	if err != nil {
 		return fmt.Errorf("failed to read flag %s: %w", fpEotsPkFlag, err)
+	}
+
+	if eotsPkHex == "" {
+		return fmt.Errorf("eots-pk cannot be empty")
 	}
 
 	info, err := client.CreateFinalityProvider(

--- a/finality-provider/service/app.go
+++ b/finality-provider/service/app.go
@@ -405,7 +405,7 @@ func (app *FinalityProviderApp) handleCreateFinalityProviderRequest(req *createF
 	fpAddr, err := kr.Address(req.passPhrase)
 	if err != nil {
 		// the chain key does not exist, should create the chain key first
-		return nil, fmt.Errorf("the keyname %s does not exist, add the key first: %w", err)
+		return nil, fmt.Errorf("the keyname %s does not exist, add the key first: %w", req.keyName, err)
 	}
 
 	// 2. create proof-of-possession

--- a/finality-provider/service/app.go
+++ b/finality-provider/service/app.go
@@ -405,44 +405,30 @@ func (app *FinalityProviderApp) handleCreateFinalityProviderRequest(req *createF
 	fpAddr, err := kr.Address(req.passPhrase)
 	if err != nil {
 		// the chain key does not exist, should create the chain key first
-		keyInfo, err := kr.CreateChainKey(req.passPhrase, req.hdPath, "")
-		if err != nil {
-			return nil, fmt.Errorf("failed to create chain key %s: %w", req.keyName, err)
-		}
-		fpAddr = keyInfo.AccAddress
+		return nil, fmt.Errorf("the keyname %s does not exist, add the key first: %w", err)
 	}
 
-	// 2. create EOTS key
-	fpPk := req.eotsPk
-	if req.eotsPk == nil {
-		fpPkBytes, err := app.eotsManager.CreateKey(req.keyName, req.passPhrase, req.hdPath)
-		if err != nil {
-			return nil, err
-		}
-		fpPk, err = bbntypes.NewBIP340PubKey(fpPkBytes)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	// 3. create proof-of-possession
-	pop, err := app.CreatePop(fpAddr, fpPk, req.passPhrase)
+	// 2. create proof-of-possession
+	pop, err := app.CreatePop(fpAddr, req.eotsPk, req.passPhrase)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create proof-of-possession of the finality-provider: %w", err)
 	}
 
-	if err := app.fps.CreateFinalityProvider(fpAddr, fpPk.MustToBTCPK(), req.description, req.commission, req.keyName, req.chainID, pop.BtcSig); err != nil {
+	btcPk := req.eotsPk.MustToBTCPK()
+	if err := app.fps.CreateFinalityProvider(fpAddr, btcPk, req.description, req.commission, req.keyName, req.chainID, pop.BtcSig); err != nil {
 		return nil, fmt.Errorf("failed to save finality-provider: %w", err)
 	}
-	app.fpManager.metrics.RecordFpStatus(fpPk.MarshalHex(), proto.FinalityProviderStatus_CREATED)
+
+	pkHex := req.eotsPk.MarshalHex()
+	app.fpManager.metrics.RecordFpStatus(pkHex, proto.FinalityProviderStatus_CREATED)
 
 	app.logger.Info("successfully created a finality-provider",
-		zap.String("btc_pk", fpPk.MarshalHex()),
+		zap.String("eots_pk", pkHex),
 		zap.String("addr", fpAddr.String()),
 		zap.String("key_name", req.keyName),
 	)
 
-	storedFp, err := app.fps.GetFinalityProvider(fpPk.MustToBTCPK())
+	storedFp, err := app.fps.GetFinalityProvider(btcPk)
 	if err != nil {
 		return nil, err
 	}

--- a/finality-provider/service/app.go
+++ b/finality-provider/service/app.go
@@ -409,6 +409,9 @@ func (app *FinalityProviderApp) handleCreateFinalityProviderRequest(req *createF
 	}
 
 	// 2. create proof-of-possession
+	if req.eotsPk == nil {
+		return nil, fmt.Errorf("eots pk cannot be nil")
+	}
 	pop, err := app.CreatePop(fpAddr, req.eotsPk, req.passPhrase)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create proof-of-possession of the finality-provider: %w", err)

--- a/finality-provider/service/app_test.go
+++ b/finality-provider/service/app_test.go
@@ -83,22 +83,16 @@ func FuzzRegisterFinalityProvider(f *testing.F) {
 		}()
 
 		var eotsPk *bbntypes.BIP340PubKey
-		eotsPk = nil
-		generateEotsKeyBefore := r.Int31n(10) > 5
-		if generateEotsKeyBefore {
-			// sometimes uses the previously generated EOTS pk
-			eotsKeyName := testutil.GenRandomHexStr(r, 4)
-			eotsPkBz, err := em.CreateKey(eotsKeyName, passphrase, hdPath)
-			require.NoError(t, err)
-			eotsPk, err = bbntypes.NewBIP340PubKey(eotsPkBz)
-			require.NoError(t, err)
-		}
+		eotsKeyName := testutil.GenRandomHexStr(r, 4)
+		require.NoError(t, err)
+		eotsPkBz, err := em.CreateKey(eotsKeyName, passphrase, hdPath)
+		require.NoError(t, err)
+		eotsPk, err = bbntypes.NewBIP340PubKey(eotsPkBz)
+		require.NoError(t, err)
 
 		// create a finality-provider object and save it to db
 		fp := testutil.GenStoredFinalityProvider(r, t, app, passphrase, hdPath, eotsPk)
-		if generateEotsKeyBefore {
-			require.Equal(t, eotsPk, bbntypes.NewBIP340PubKeyFromBTCPK(fp.BtcPk))
-		}
+		require.Equal(t, eotsPk, bbntypes.NewBIP340PubKeyFromBTCPK(fp.BtcPk))
 
 		btcSig := new(bbntypes.BIP340Signature)
 		err = btcSig.Unmarshal(fp.Pop.BtcSig)
@@ -199,7 +193,13 @@ func FuzzSyncFinalityProviderStatus(f *testing.F) {
 		err = app.Start()
 		require.NoError(t, err)
 
-		fp := testutil.GenStoredFinalityProvider(r, t, app, "", hdPath, nil)
+		eotsKeyName := testutil.GenRandomHexStr(r, 4)
+		require.NoError(t, err)
+		eotsPkBz, err := em.CreateKey(eotsKeyName, passphrase, hdPath)
+		require.NoError(t, err)
+		eotsPk, err := bbntypes.NewBIP340PubKey(eotsPkBz)
+		require.NoError(t, err)
+		fp := testutil.GenStoredFinalityProvider(r, t, app, "", hdPath, eotsPk)
 
 		require.Eventually(t, func() bool {
 			fpPk := fp.GetBIP340BTCPK()
@@ -277,7 +277,13 @@ func FuzzUnjailFinalityProvider(f *testing.F) {
 		}()
 		require.NoError(t, err)
 
-		fp := testutil.GenStoredFinalityProvider(r, t, app, "", hdPath, nil)
+		eotsKeyName := testutil.GenRandomHexStr(r, 4)
+		require.NoError(t, err)
+		eotsPkBz, err := em.CreateKey(eotsKeyName, passphrase, hdPath)
+		require.NoError(t, err)
+		eotsPk, err := bbntypes.NewBIP340PubKey(eotsPkBz)
+		require.NoError(t, err)
+		fp := testutil.GenStoredFinalityProvider(r, t, app, "", hdPath, eotsPk)
 		err = app.GetFinalityProviderStore().SetFpStatus(fp.BtcPk, proto.FinalityProviderStatus_JAILED)
 		require.NoError(t, err)
 

--- a/finality-provider/service/fp_instance_test.go
+++ b/finality-provider/service/fp_instance_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	bbntypes "github.com/babylonlabs-io/babylon/types"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -122,7 +123,13 @@ func startFinalityProviderAppWithRegisteredFp(t *testing.T, r *rand.Rand, cc cli
 	require.NoError(t, err)
 
 	// create registered finality-provider
-	fp := testutil.GenStoredFinalityProvider(r, t, app, passphrase, hdPath, nil)
+	eotsKeyName := testutil.GenRandomHexStr(r, 4)
+	require.NoError(t, err)
+	eotsPkBz, err := em.CreateKey(eotsKeyName, passphrase, hdPath)
+	require.NoError(t, err)
+	eotsPk, err := bbntypes.NewBIP340PubKey(eotsPkBz)
+	require.NoError(t, err)
+	fp := testutil.GenStoredFinalityProvider(r, t, app, passphrase, hdPath, eotsPk)
 	pubRandProofStore := app.GetPubRandProofStore()
 	fpStore := app.GetFinalityProviderStore()
 	err = fpStore.SetFpStatus(fp.BtcPk, proto.FinalityProviderStatus_REGISTERED)

--- a/finality-provider/service/rpcserver.go
+++ b/finality-provider/service/rpcserver.go
@@ -95,7 +95,7 @@ func (r *rpcServer) CreateFinalityProvider(
 		return nil, err
 	}
 
-	eotsPk, err := parseOptEotsPk(req.EotsPkHex)
+	eotsPk, err := parseEotsPk(req.EotsPkHex)
 	if err != nil {
 		return nil, err
 	}
@@ -296,9 +296,10 @@ func (r *rpcServer) SignMessageFromChainKey(_ context.Context, req *proto.SignMe
 	return &proto.SignMessageFromChainKeyResponse{Signature: signature}, nil
 }
 
-func parseOptEotsPk(eotsPkHex string) (*bbntypes.BIP340PubKey, error) {
-	if len(eotsPkHex) > 0 {
-		return bbntypes.NewBIP340PubKeyFromHex(eotsPkHex)
+func parseEotsPk(eotsPkHex string) (*bbntypes.BIP340PubKey, error) {
+	if eotsPkHex == "" {
+		return nil, fmt.Errorf("eots-pk cannot be empty")
 	}
-	return nil, nil
+
+	return bbntypes.NewBIP340PubKeyFromHex(eotsPkHex)
 }

--- a/itest/test_manager.go
+++ b/itest/test_manager.go
@@ -213,7 +213,13 @@ func StartManagerWithFinalityProvider(t *testing.T) (*TestManager, *service.Fina
 	_, _, err = tm.manager.BabylondTxBankSend(t, fpBbnKeyInfo.AccAddress.String(), "1000000ubbn", "node0")
 	require.NoError(t, err)
 
-	res, err := app.CreateFinalityProvider(testFpName, testChainID, passphrase, hdPath, nil, desc, &commission)
+	eotsKeyName := "eots-key"
+	require.NoError(t, err)
+	eotsPkBz, err := tm.EOTSClient.CreateKey(eotsKeyName, passphrase, hdPath)
+	require.NoError(t, err)
+	eotsPk, err := bbntypes.NewBIP340PubKey(eotsPkBz)
+	require.NoError(t, err)
+	res, err := app.CreateFinalityProvider(testFpName, testChainID, passphrase, hdPath, eotsPk, desc, &commission)
 	require.NoError(t, err)
 	fpPk, err := bbntypes.NewBIP340PubKeyFromHex(res.FpInfo.BtcPkHex)
 	require.NoError(t, err)


### PR DESCRIPTION
Closes #162. Also marked some flags as required:
- eots-pk
- chain-id
- key-name
- commission
- moniker