### PR TITLE
chore(cmd): adds eotsd version command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 * [#175](https://github.com/babylonlabs-io/finality-provider/pull/175) adds: `eotsd version` command
 
-
 ### Bug Fixes
 
 * [#166](https://github.com/babylonlabs-io/finality-provider/pull/166) fix: `eotsd keys add` `--output` flag

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## Unreleased
 
+### Improvements
+
+* [#175](https://github.com/babylonlabs-io/finality-provider/pull/175) adds: `eotsd version` command
+
+
 ### Bug Fixes
 
 * [#166](https://github.com/babylonlabs-io/finality-provider/pull/166) fix: `eotsd keys add` `--output` flag

--- a/eotsmanager/cmd/eotsd/daemon/root.go
+++ b/eotsmanager/cmd/eotsd/daemon/root.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"github.com/babylonlabs-io/finality-provider/version"
 	"github.com/cosmos/cosmos-sdk/client"
 	sdkflags "github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/spf13/cobra"
@@ -23,6 +24,7 @@ func NewRootCmd() *cobra.Command {
 		NewInitCmd(),
 		NewKeysCmd(),
 		NewStartCmd(),
+		version.CommandVersion("eotsd"),
 	)
 
 	return rootCmd

--- a/finality-provider/cmd/fpd/daemon/daemon_commands.go
+++ b/finality-provider/cmd/fpd/daemon/daemon_commands.go
@@ -2,22 +2,18 @@ package daemon
 
 import (
 	"context"
+	"cosmossdk.io/math"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"strconv"
-	"strings"
-
-	"github.com/babylonlabs-io/finality-provider/finality-provider/proto"
-	fpversion "github.com/babylonlabs-io/finality-provider/version"
-
-	"cosmossdk.io/math"
 	"github.com/babylonlabs-io/babylon/types"
+	"github.com/babylonlabs-io/finality-provider/finality-provider/proto"
 	"github.com/cosmos/cosmos-sdk/client"
 	sdkflags "github.com/cosmos/cosmos-sdk/client/flags"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"strconv"
 
 	fpcmd "github.com/babylonlabs-io/finality-provider/finality-provider/cmd"
 	fpcfg "github.com/babylonlabs-io/finality-provider/finality-provider/config"
@@ -569,34 +565,4 @@ func loadKeyName(homeDir string, cmd *cobra.Command) (string, error) {
 		return "", fmt.Errorf("the key in config is empty")
 	}
 	return keyName, nil
-}
-
-// CommandVersion prints cmd version
-func CommandVersion() *cobra.Command {
-	var cmd = &cobra.Command{
-		Use:     "version",
-		Short:   "Prints version of this binary.",
-		Aliases: []string{"v"},
-		Example: `fpd version`,
-		Args:    cobra.NoArgs,
-		Run: func(cmd *cobra.Command, _ []string) {
-			version := fpversion.Version()
-			commit, ts := fpversion.CommitInfo()
-
-			if version == "" {
-				version = "main"
-			}
-
-			var sb strings.Builder
-			_, _ = sb.WriteString("Version:       " + version)
-			_, _ = sb.WriteString("\n")
-			_, _ = sb.WriteString("Git Commit:    " + commit)
-			_, _ = sb.WriteString("\n")
-			_, _ = sb.WriteString("Git Timestamp: " + ts)
-			_, _ = sb.WriteString("\n")
-
-			cmd.Printf(sb.String()) //nolint:govet // it's not an issue
-		},
-	}
-	return cmd
 }

--- a/finality-provider/cmd/fpd/main.go
+++ b/finality-provider/cmd/fpd/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"github.com/babylonlabs-io/finality-provider/version"
 	"os"
 
 	"github.com/cosmos/cosmos-sdk/client"
@@ -34,7 +35,7 @@ func main() {
 		daemon.CommandGetDaemonInfo(), daemon.CommandCreateFP(), daemon.CommandLsFP(),
 		daemon.CommandInfoFP(), daemon.CommandRegisterFP(), daemon.CommandAddFinalitySig(),
 		daemon.CommandExportFP(), daemon.CommandTxs(), daemon.CommandUnjailFP(),
-		daemon.CommandEditFinalityDescription(), daemon.CommandVersion(),
+		daemon.CommandEditFinalityDescription(), version.CommandVersion("fpd"),
 		daemon.CommandCommitPubRand(),
 	)
 

--- a/version/cmd.go
+++ b/version/cmd.go
@@ -12,7 +12,7 @@ func CommandVersion(binaryName string) *cobra.Command {
 		Use:     "version",
 		Short:   "Prints version of this binary.",
 		Aliases: []string{"v"},
-		Example: fmt.Sprintf("%s version"),
+		Example: fmt.Sprintf("%s version", binaryName),
 		Args:    cobra.NoArgs,
 		Run: func(cmd *cobra.Command, _ []string) {
 			v := Version()

--- a/version/cmd.go
+++ b/version/cmd.go
@@ -1,0 +1,37 @@
+package version
+
+import (
+	"fmt"
+	"github.com/spf13/cobra"
+	"strings"
+)
+
+// CommandVersion prints cmd version
+func CommandVersion(binaryName string) *cobra.Command {
+	var cmd = &cobra.Command{
+		Use:     "version",
+		Short:   "Prints version of this binary.",
+		Aliases: []string{"v"},
+		Example: fmt.Sprintf("%s version"),
+		Args:    cobra.NoArgs,
+		Run: func(cmd *cobra.Command, _ []string) {
+			v := Version()
+			commit, ts := CommitInfo()
+
+			if v == "" {
+				v = "main"
+			}
+
+			var sb strings.Builder
+			_, _ = sb.WriteString("Version:       " + v)
+			_, _ = sb.WriteString("\n")
+			_, _ = sb.WriteString("Git Commit:    " + commit)
+			_, _ = sb.WriteString("\n")
+			_, _ = sb.WriteString("Git Timestamp: " + ts)
+			_, _ = sb.WriteString("\n")
+
+			cmd.Printf(sb.String()) //nolint:govet // it's not an issue
+		},
+	}
+	return cmd
+}


### PR DESCRIPTION
```
lazar@Lazars-MacBook-Pro finality-provider % ./build/eotsd v
Version:       0.12.0-9-g965510a
Git Commit:    965510a
Git Timestamp: 2024-11-28T12:51:34Z

```

[tracking issue](https://github.com/babylonlabs-io/finality-provider/issues/174)