### PR TITLE
chore(adr-35): Refactor determining start height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@ empty HD path to derive new key and use master private key.
 * [#154](https://github.com/babylonlabs-io/finality-provider/pull/154) Use sign schnorr instead of getting private key from EOTS manager
 * [#167](https://github.com/babylonlabs-io/finality-provider/pull/167) Remove last processed height
 * [#168](https://github.com/babylonlabs-io/finality-provider/pull/168) Remove key creation in `create-finality-provider`
+* [#176](https://github.com/babylonlabs-io/finality-provider/pull/176) Refactor
+determining start height based on [ADR-35](https://github.com/babylonlabs-io/pm/blob/main/adr/adr-035-slashing-protection.md)
 
 ### v0.12.1
 

--- a/clientcontroller/babylon.go
+++ b/clientcontroller/babylon.go
@@ -297,6 +297,17 @@ func (bc *BabylonController) QueryFinalityProviderVotingPower(fpPk *btcec.Public
 	return res.VotingPower, nil
 }
 
+// QueryFinalityProviderHighestVotedHeight queries the highest voted height of the given finality provider
+func (bc *BabylonController) QueryFinalityProviderHighestVotedHeight(fpPk *btcec.PublicKey) (uint64, error) {
+	fpPubKey := bbntypes.NewBIP340PubKeyFromBTCPK(fpPk)
+	res, err := bc.bbnClient.QueryClient.FinalityProvider(fpPubKey.MarshalHex())
+	if err != nil {
+		return 0, fmt.Errorf("failed to query highest voted height for finality provider %s: %w", fpPubKey.MarshalHex(), err)
+	}
+
+	return uint64(res.FinalityProvider.HighestVotedHeight), nil
+}
+
 func (bc *BabylonController) QueryLatestFinalizedBlocks(count uint64) ([]*types.BlockInfo, error) {
 	return bc.queryLatestBlocks(nil, count, finalitytypes.QueriedBlockStatus_FINALIZED, true)
 }

--- a/clientcontroller/interface.go
+++ b/clientcontroller/interface.go
@@ -31,6 +31,9 @@ type ClientController interface {
 		description []byte,
 	) (*types.TxResponse, error)
 
+	// EditFinalityProvider edits description and commission of a finality provider
+	EditFinalityProvider(fpPk *btcec.PublicKey, commission *math.LegacyDec, description []byte) (*btcstakingtypes.MsgEditFinalityProvider, error)
+
 	// CommitPubRandList commits a list of EOTS public randomness the consumer chain
 	// it returns tx hash and error
 	CommitPubRandList(fpPk *btcec.PublicKey, startHeight uint64, numPubRand uint64, commitment []byte, sig *schnorr.Signature) (*types.TxResponse, error)
@@ -44,14 +47,18 @@ type ClientController interface {
 	// UnjailFinalityProvider sends an unjail transaction to the consumer chain
 	UnjailFinalityProvider(fpPk *btcec.PublicKey) (*types.TxResponse, error)
 
+	/*
+		The following methods are queries to the consumer chain
+	*/
+
 	// QueryFinalityProviderVotingPower queries the voting power of the finality provider at a given height
 	QueryFinalityProviderVotingPower(fpPk *btcec.PublicKey, blockHeight uint64) (uint64, error)
 
 	// QueryFinalityProviderSlashedOrJailed queries if the finality provider is slashed or jailed
 	QueryFinalityProviderSlashedOrJailed(fpPk *btcec.PublicKey) (slashed bool, jailed bool, err error)
 
-	// EditFinalityProvider edits description and commission of a finality provider
-	EditFinalityProvider(fpPk *btcec.PublicKey, commission *math.LegacyDec, description []byte) (*btcstakingtypes.MsgEditFinalityProvider, error)
+	// QueryFinalityProviderHighestVotedHeight queries the highest voted height of the given finality provider
+	QueryFinalityProviderHighestVotedHeight(fpPk *btcec.PublicKey) (uint64, error)
 
 	// QueryLatestFinalizedBlocks returns the latest finalized blocks
 	QueryLatestFinalizedBlocks(count uint64) ([]*types.BlockInfo, error)

--- a/finality-provider/service/app_test.go
+++ b/finality-provider/service/app_test.go
@@ -186,6 +186,7 @@ func FuzzSyncFinalityProviderStatus(f *testing.F) {
 			mockClientController.EXPECT().QueryActivatedHeight().Return(currentHeight, nil).AnyTimes()
 			mockClientController.EXPECT().QueryFinalityProviderVotingPower(gomock.Any(), gomock.Any()).Return(uint64(2), nil).AnyTimes()
 		}
+		mockClientController.EXPECT().QueryFinalityProviderHighestVotedHeight(gomock.Any()).Return(uint64(0), nil).AnyTimes()
 
 		app, err := service.NewFinalityProviderApp(&fpCfg, mockClientController, em, fpdb, logger)
 		require.NoError(t, err)
@@ -266,6 +267,7 @@ func FuzzUnjailFinalityProvider(f *testing.F) {
 		mockClientController.EXPECT().QueryFinalityProviderVotingPower(gomock.Any(), gomock.Any()).Return(uint64(0), nil).AnyTimes()
 		mockClientController.EXPECT().QueryActivatedHeight().Return(uint64(1), nil).AnyTimes()
 		mockClientController.EXPECT().QueryFinalityProviderSlashedOrJailed(gomock.Any()).Return(false, false, nil).AnyTimes()
+		mockClientController.EXPECT().QueryFinalityProviderHighestVotedHeight(gomock.Any()).Return(uint64(0), nil).AnyTimes()
 
 		app, err := service.NewFinalityProviderApp(&fpCfg, mockClientController, em, fpdb, logger)
 		require.NoError(t, err)

--- a/finality-provider/service/fp_instance.go
+++ b/finality-provider/service/fp_instance.go
@@ -114,7 +114,7 @@ func (fp *FinalityProviderInstance) Start() error {
 
 	fp.logger.Info("Starting finality-provider instance", zap.String("pk", fp.GetBtcPkHex()))
 
-	startHeight, err := fp.determinePollerStartingHeight()
+	startHeight, err := fp.DetermineStartHeight()
 	if err != nil {
 		return fmt.Errorf("failed to get the start height: %w", err)
 	}
@@ -732,7 +732,7 @@ func (fp *FinalityProviderInstance) TestSubmitFinalitySignatureAndExtractPrivKey
 	return res, privKey, nil
 }
 
-// determinePollerStartingHeight determines the starting height for block processing by:
+// DetermineStartHeight determines trting height for block processing by:
 //
 // If AutoChainScanningMode is disabled:
 //   - Returns StaticChainScanningStartHeight from config
@@ -753,7 +753,7 @@ func (fp *FinalityProviderInstance) TestSubmitFinalitySignatureAndExtractPrivKey
 //
 // Note: Starting from lastFinalizedHeight when there's a gap to the last processed height
 // may result in missed rewards, depending on the consumer chain's reward distribution mechanism.
-func (fp *FinalityProviderInstance) determinePollerStartingHeight() (uint64, error) {
+func (fp *FinalityProviderInstance) DetermineStartHeight() (uint64, error) {
 	// start from a height from config if AutoChainScanningMode is disabled
 	if !fp.cfg.PollerConfig.AutoChainScanningMode {
 		fp.logger.Info("using static chain scanning mode",

--- a/finality-provider/service/fp_instance.go
+++ b/finality-provider/service/fp_instance.go
@@ -732,7 +732,7 @@ func (fp *FinalityProviderInstance) TestSubmitFinalitySignatureAndExtractPrivKey
 	return res, privKey, nil
 }
 
-// DetermineStartHeight determines trting height for block processing by:
+// DetermineStartHeight determines start height for block processing by:
 //
 // If AutoChainScanningMode is disabled:
 //   - Returns StaticChainScanningStartHeight from config

--- a/finality-provider/service/fp_manager_test.go
+++ b/finality-provider/service/fp_manager_test.go
@@ -56,6 +56,7 @@ func FuzzStatusUpdate(f *testing.F) {
 		mockClientController.EXPECT().QueryBestBlock().Return(currentBlockRes, nil).AnyTimes()
 		mockClientController.EXPECT().QueryActivatedHeight().Return(uint64(1), nil).AnyTimes()
 		mockClientController.EXPECT().QueryFinalityActivationBlockHeight().Return(uint64(0), nil).AnyTimes()
+		mockClientController.EXPECT().QueryFinalityProviderHighestVotedHeight(gomock.Any()).Return(uint64(0), nil).AnyTimes()
 		mockClientController.EXPECT().QueryBlock(gomock.Any()).Return(currentBlockRes, nil).AnyTimes()
 		mockClientController.EXPECT().QueryLastCommittedPublicRand(gomock.Any(), uint64(1)).Return(nil, nil).AnyTimes()
 

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	cosmossdk.io/errors v1.0.1
 	cosmossdk.io/math v1.4.0
 	github.com/avast/retry-go/v4 v4.5.1
-	github.com/babylonlabs-io/babylon v0.17.1
+	github.com/babylonlabs-io/babylon v0.9.3-0.20241128025442-457909d8c43c
 	github.com/btcsuite/btcd v0.24.2
 	github.com/btcsuite/btcd/btcec/v2 v2.3.2
 	github.com/btcsuite/btcd/btcutil v1.1.6

--- a/go.sum
+++ b/go.sum
@@ -1427,8 +1427,8 @@ github.com/aws/aws-sdk-go v1.44.122/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX
 github.com/aws/aws-sdk-go v1.44.312 h1:llrElfzeqG/YOLFFKjg1xNpZCFJ2xraIi3PqSuP+95k=
 github.com/aws/aws-sdk-go v1.44.312/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
 github.com/aws/aws-sdk-go-v2 v0.18.0/go.mod h1:JWVYvqSMppoMJC0x5wdwiImzgXTI9FuZwxzkQq9wy+g=
-github.com/babylonlabs-io/babylon v0.17.1 h1:lyWGdR7B49qDw5pllLyTW/HAM5uQWXXPZefjFzy/Xy0=
-github.com/babylonlabs-io/babylon v0.17.1/go.mod h1:sT+KG2U+M0tDMNZZ2L5CwlXX0OpagGEs56BiWXqaZFw=
+github.com/babylonlabs-io/babylon v0.9.3-0.20241128025442-457909d8c43c h1:BfanV3d5TsQa/8xyj3mOlquW5ooRNMoK1Y8HDqcyAzk=
+github.com/babylonlabs-io/babylon v0.9.3-0.20241128025442-457909d8c43c/go.mod h1:sT+KG2U+M0tDMNZZ2L5CwlXX0OpagGEs56BiWXqaZFw=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=

--- a/itest/container/config.go
+++ b/itest/container/config.go
@@ -1,8 +1,6 @@
 package container
 
 import (
-	"github.com/babylonlabs-io/finality-provider/testutil"
-	"github.com/stretchr/testify/require"
 	"testing"
 )
 
@@ -20,10 +18,11 @@ const (
 
 // NewImageConfig returns ImageConfig needed for running e2e test.
 func NewImageConfig(t *testing.T) ImageConfig {
-	babylondVersion, err := testutil.GetBabylonVersion()
-	require.NoError(t, err)
+	// TODO: currently use specific commit, should uncomment after having a new release
+	// babylondVersion, err := testutil.GetBabylonVersion()
+	// require.NoError(t, err)
 	return ImageConfig{
 		BabylonRepository: dockerBabylondRepository,
-		BabylonVersion:    babylondVersion,
+		BabylonVersion:    "457909d8c43c8483655c2d3a3a01cd2190344fd4",
 	}
 }

--- a/testutil/mocks/babylon.go
+++ b/testutil/mocks/babylon.go
@@ -98,21 +98,6 @@ func (mr *MockClientControllerMockRecorder) QueryActivatedHeight() *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueryActivatedHeight", reflect.TypeOf((*MockClientController)(nil).QueryActivatedHeight))
 }
 
-// QueryFinalityActivationBlockHeight mocks base method.
-func (m *MockClientController) QueryFinalityActivationBlockHeight() (uint64, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "QueryFinalityActivationBlockHeight")
-	ret0, _ := ret[0].(uint64)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// QueryFinalityActivationBlockHeight indicates an expected call of QueryFinalityActivationBlockHeight.
-func (mr *MockClientControllerMockRecorder) QueryFinalityActivationBlockHeight() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueryFinalityActivationBlockHeight", reflect.TypeOf((*MockClientController)(nil).QueryFinalityActivationBlockHeight))
-}
-
 // QueryBestBlock mocks base method.
 func (m *MockClientController) QueryBestBlock() (*types1.BlockInfo, error) {
 	m.ctrl.T.Helper()
@@ -156,6 +141,36 @@ func (m *MockClientController) QueryBlocks(startHeight, endHeight uint64, limit 
 func (mr *MockClientControllerMockRecorder) QueryBlocks(startHeight, endHeight, limit interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueryBlocks", reflect.TypeOf((*MockClientController)(nil).QueryBlocks), startHeight, endHeight, limit)
+}
+
+// QueryFinalityActivationBlockHeight mocks base method.
+func (m *MockClientController) QueryFinalityActivationBlockHeight() (uint64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "QueryFinalityActivationBlockHeight")
+	ret0, _ := ret[0].(uint64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// QueryFinalityActivationBlockHeight indicates an expected call of QueryFinalityActivationBlockHeight.
+func (mr *MockClientControllerMockRecorder) QueryFinalityActivationBlockHeight() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueryFinalityActivationBlockHeight", reflect.TypeOf((*MockClientController)(nil).QueryFinalityActivationBlockHeight))
+}
+
+// QueryFinalityProviderHighestVotedHeight mocks base method.
+func (m *MockClientController) QueryFinalityProviderHighestVotedHeight(fpPk *btcec.PublicKey) (uint64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "QueryFinalityProviderHighestVotedHeight", fpPk)
+	ret0, _ := ret[0].(uint64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// QueryFinalityProviderHighestVotedHeight indicates an expected call of QueryFinalityProviderHighestVotedHeight.
+func (mr *MockClientControllerMockRecorder) QueryFinalityProviderHighestVotedHeight(fpPk interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueryFinalityProviderHighestVotedHeight", reflect.TypeOf((*MockClientController)(nil).QueryFinalityProviderHighestVotedHeight), fpPk)
 }
 
 // QueryFinalityProviderSlashedOrJailed mocks base method.


### PR DESCRIPTION
Closes #119 by adding highest voted height into consideration of determining start height. This implements the finality provider part of [ADR-35](https://github.com/babylonlabs-io/pm/blob/main/adr/adr-035-slashing-protection.md)