### PR TITLE
chore: refactor op e2e tests - part 3

### DIFF
--- a/itest/opstackl2/op_e2e_test.go
+++ b/itest/opstackl2/op_e2e_test.go
@@ -4,11 +4,52 @@
 package e2etest_op
 
 import (
+	"encoding/json"
 	"testing"
+
+	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
+	opcc "github.com/babylonlabs-io/finality-provider/clientcontroller/opstackl2"
+	e2eutils "github.com/babylonlabs-io/finality-provider/itest"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
 
 // This test case will be removed by the final PR
 func TestOpTestManagerSetup(t *testing.T) {
 	ctm := StartOpL2ConsumerManager(t)
 	defer ctm.Stop(t)
+
+	// setup logger
+	config := zap.NewDevelopmentConfig()
+	config.Level = zap.NewAtomicLevelAt(zapcore.Level(zap.DebugLevel))
+	logger, err := config.Build()
+	require.NoError(t, err)
+
+	// create cosmwasm client
+	cwConfig := ctm.OpConsumerController.Cfg.ToCosmwasmConfig()
+	cwClient, err := opcc.NewCwClient(&cwConfig, logger)
+	require.NoError(t, err)
+
+	// query cw contract config
+	queryMsg := map[string]interface{}{
+		"config": struct{}{},
+	}
+	queryMsgBytes, err := json.Marshal(queryMsg)
+	require.NoError(t, err)
+
+	var queryConfigResponse *wasmtypes.QuerySmartContractStateResponse
+	require.Eventually(t, func() bool {
+		queryConfigResponse, err = cwClient.QuerySmartContractState(
+			ctm.OpConsumerController.Cfg.OPFinalityGadgetAddress,
+			string(queryMsgBytes),
+		)
+		return err == nil
+	}, e2eutils.EventuallyWaitTimeOut, e2eutils.EventuallyPollTime)
+
+	var cfgResp Config
+	err = json.Unmarshal(queryConfigResponse.Data, &cfgResp)
+	require.NoError(t, err)
+	t.Logf("Response config query from CW contract: %+v", cfgResp)
+	require.Equal(t, opConsumerChainId, cfgResp.ConsumerId)
 }

--- a/itest/opstackl2/op_e2e_test.go
+++ b/itest/opstackl2/op_e2e_test.go
@@ -4,15 +4,7 @@
 package e2etest_op
 
 import (
-	"encoding/json"
 	"testing"
-
-	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
-	opcc "github.com/babylonlabs-io/finality-provider/clientcontroller/opstackl2"
-	e2eutils "github.com/babylonlabs-io/finality-provider/itest"
-	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 )
 
 // This test case will be removed by the final PR
@@ -20,36 +12,9 @@ func TestOpTestManagerSetup(t *testing.T) {
 	ctm := StartOpL2ConsumerManager(t)
 	defer ctm.Stop(t)
 
-	// setup logger
-	config := zap.NewDevelopmentConfig()
-	config.Level = zap.NewAtomicLevelAt(zapcore.Level(zap.DebugLevel))
-	logger, err := config.Build()
-	require.NoError(t, err)
+	// create and register Babylon FP and OP consumer FP
+	fps := ctm.setupBabylonAndConsumerFp(t)
 
-	// create cosmwasm client
-	cwConfig := ctm.OpConsumerController.Cfg.ToCosmwasmConfig()
-	cwClient, err := opcc.NewCwClient(&cwConfig, logger)
-	require.NoError(t, err)
-
-	// query cw contract config
-	queryMsg := map[string]interface{}{
-		"config": struct{}{},
-	}
-	queryMsgBytes, err := json.Marshal(queryMsg)
-	require.NoError(t, err)
-
-	var queryConfigResponse *wasmtypes.QuerySmartContractStateResponse
-	require.Eventually(t, func() bool {
-		queryConfigResponse, err = cwClient.QuerySmartContractState(
-			ctm.OpConsumerController.Cfg.OPFinalityGadgetAddress,
-			string(queryMsgBytes),
-		)
-		return err == nil
-	}, e2eutils.EventuallyWaitTimeOut, e2eutils.EventuallyPollTime)
-
-	var cfgResp Config
-	err = json.Unmarshal(queryConfigResponse.Data, &cfgResp)
-	require.NoError(t, err)
-	t.Logf("Response config query from CW contract: %+v", cfgResp)
-	require.Equal(t, opConsumerChainId, cfgResp.ConsumerId)
+	// send a BTC delegation and wait for activation
+	ctm.delegateBTCAndWaitForActivation(t, fps[0], fps[1])
 }

--- a/itest/opstackl2/op_test_manager.go
+++ b/itest/opstackl2/op_test_manager.go
@@ -11,16 +11,12 @@ import (
 	"testing"
 	"time"
 
-	sdkmath "cosmossdk.io/math"
 	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
 	bbncfg "github.com/babylonlabs-io/babylon/client/config"
 	bbntypes "github.com/babylonlabs-io/babylon/types"
-	"github.com/babylonlabs-io/finality-provider/clientcontroller/api"
 	bbncc "github.com/babylonlabs-io/finality-provider/clientcontroller/babylon"
 	opcc "github.com/babylonlabs-io/finality-provider/clientcontroller/opstackl2"
 	cwclient "github.com/babylonlabs-io/finality-provider/cosmwasmclient/client"
-	"github.com/babylonlabs-io/finality-provider/eotsmanager/client"
-	eotsclient "github.com/babylonlabs-io/finality-provider/eotsmanager/client"
 	eotsconfig "github.com/babylonlabs-io/finality-provider/eotsmanager/config"
 	fpcfg "github.com/babylonlabs-io/finality-provider/finality-provider/config"
 	"github.com/babylonlabs-io/finality-provider/finality-provider/service"
@@ -113,14 +109,14 @@ func StartOpL2ConsumerManager(t *testing.T) *OpL2ConsumerTestManager {
 	require.NoError(t, err)
 
 	// create EOTS handler and EOTS gRPC clients for Babylon and consumer
-	eotsHandler, EOTSClients := startEotsManagers(t, logger, testDir, babylonFpCfg, consumerFpCfg, &shutdownInterceptor)
+	eotsHandler, EOTSClients := base_test_manager.StartEotsManagers(t, logger, testDir, babylonFpCfg, consumerFpCfg, &shutdownInterceptor)
 
 	// create Babylon consumer controller
 	babylonConsumerController, err := bbncc.NewBabylonConsumerController(babylonFpCfg.BabylonConfig, &babylonFpCfg.BTCNetParams, logger)
 	require.NoError(t, err)
 
 	// create and start Babylon FP app
-	babylonFpApp := createAndStartFpApp(t, logger, babylonFpCfg, babylonConsumerController, EOTSClients[0])
+	babylonFpApp := base_test_manager.CreateAndStartFpApp(t, logger, babylonFpCfg, babylonConsumerController, EOTSClients[0])
 	t.Log(log.Prefix("Started Babylon FP App"))
 
 	// create op consumer controller
@@ -128,7 +124,7 @@ func StartOpL2ConsumerManager(t *testing.T) *OpL2ConsumerTestManager {
 	require.NoError(t, err)
 
 	// create and start consumer FP app
-	consumerFpApp := createAndStartFpApp(t, logger, consumerFpCfg, opConsumerController, EOTSClients[1])
+	consumerFpApp := base_test_manager.CreateAndStartFpApp(t, logger, consumerFpCfg, opConsumerController, EOTSClients[1])
 	t.Log(log.Prefix("Started Consumer FP App"))
 
 	ctm := &OpL2ConsumerTestManager{
@@ -315,100 +311,9 @@ func deployCwContract(t *testing.T, cwClient *cwclient.Client) string {
 	return listContractsResponse.Contracts[0]
 }
 
-func startEotsManagers(
-	t *testing.T,
-	logger *zap.Logger,
-	testDir string,
-	babylonFpCfg *fpcfg.Config,
-	consumerFpCfg *fpcfg.Config,
-	shutdownInterceptor *signal.Interceptor,
-) (*e2eutils.EOTSServerHandler, []*eotsclient.EOTSManagerGRpcClient) {
-	fpCfgs := []*fpcfg.Config{babylonFpCfg, consumerFpCfg}
-	eotsClients := make([]*eotsclient.EOTSManagerGRpcClient, len(fpCfgs))
-	eotsHomeDirs := []string{filepath.Join(testDir, "babylon-eots-home"), filepath.Join(testDir, "consumer-eots-home")}
-	eotsConfigs := make([]*eotsconfig.Config, len(fpCfgs))
-	for i := 0; i < len(fpCfgs); i++ {
-		eotsCfg := eotsconfig.DefaultConfigWithHomePathAndPorts(
-			eotsHomeDirs[i],
-			eotsconfig.DefaultRPCPort+i,
-			metrics.DefaultEotsConfig().Port+i,
-		)
-		eotsConfigs[i] = eotsCfg
-	}
-
-	eh := e2eutils.NewEOTSServerHandlerMultiFP(t, logger, eotsConfigs, eotsHomeDirs, shutdownInterceptor)
-	eh.Start()
-
-	// create EOTS clients
-	for i := 0; i < len(fpCfgs); i++ {
-		// wait for EOTS servers to start
-		// see https://github.com/babylonchain/finality-provider/pull/517
-		var eotsCli *eotsclient.EOTSManagerGRpcClient
-		var err error
-		require.Eventually(t, func() bool {
-			eotsCli, err = eotsclient.NewEOTSManagerGRpcClient(fpCfgs[i].EOTSManagerAddress)
-			if err != nil {
-				t.Logf("Error creating EOTS client: %v", err)
-				return false
-			}
-			eotsClients[i] = eotsCli
-			return true
-		}, 5*time.Second, time.Second, "Failed to create EOTS client")
-	}
-	return eh, eotsClients
-}
-
-func createAndStartFpApp(
-	t *testing.T,
-	logger *zap.Logger,
-	cfg *fpcfg.Config,
-	cc api.ConsumerController,
-	eotsCli *client.EOTSManagerGRpcClient,
-) *service.FinalityProviderApp {
-	bc, err := bbncc.NewBabylonController(cfg.BabylonConfig, &cfg.BTCNetParams, logger)
-	require.NoError(t, err)
-
-	fpdb, err := cfg.DatabaseConfig.GetDbBackend()
-	require.NoError(t, err)
-
-	fpApp, err := service.NewFinalityProviderApp(cfg, bc, cc, eotsCli, fpdb, logger)
-	require.NoError(t, err)
-
-	err = fpApp.Start()
-	require.NoError(t, err)
-
-	return fpApp
-}
-
-func createAndRegisterFinalityProvider(t *testing.T, fpApp *service.FinalityProviderApp, chainId string) *bbntypes.BIP340PubKey {
-	fpCfg := fpApp.GetConfig()
-	keyName := fpCfg.BabylonConfig.Key
-	moniker := fmt.Sprintf("%s-%s", chainId, e2eutils.MonikerPrefix)
-	commission := sdkmath.LegacyZeroDec()
-	desc := e2eutils.NewDescription(moniker)
-
-	res, err := fpApp.CreateFinalityProvider(
-		keyName,
-		chainId,
-		e2eutils.Passphrase,
-		e2eutils.HdPath,
-		nil,
-		desc,
-		&commission,
-	)
-	require.NoError(t, err)
-
-	fpPk, err := bbntypes.NewBIP340PubKeyFromHex(res.FpInfo.BtcPkHex)
-	require.NoError(t, err)
-
-	_, err = fpApp.RegisterFinalityProvider(fpPk.MarshalHex())
-	require.NoError(t, err)
-	return fpPk
-}
-
 func (ctm *OpL2ConsumerTestManager) setupBabylonAndConsumerFp(t *testing.T) []*bbntypes.BIP340PubKey {
 	// create and register Babylon FP
-	babylonFpPk := createAndRegisterFinalityProvider(t, ctm.BabylonFpApp, e2eutils.ChainID)
+	babylonFpPk := base_test_manager.CreateAndRegisterFinalityProvider(t, ctm.BabylonFpApp, e2eutils.ChainID)
 	t.Logf(log.Prefix("Registered Finality Provider %s for %s"), babylonFpPk.MarshalHex(), e2eutils.ChainID)
 
 	// wait for Babylon FP registration
@@ -418,7 +323,7 @@ func (ctm *OpL2ConsumerTestManager) setupBabylonAndConsumerFp(t *testing.T) []*b
 	}, e2eutils.EventuallyWaitTimeOut, e2eutils.EventuallyPollTime, "Failed to wait for Babylon FP registration")
 
 	// create and register consumer FP
-	consumerFpPk := createAndRegisterFinalityProvider(t, ctm.ConsumerFpApp, opConsumerChainId)
+	consumerFpPk := base_test_manager.CreateAndRegisterFinalityProvider(t, ctm.ConsumerFpApp, opConsumerChainId)
 	t.Logf(log.Prefix("Registered Finality Provider %s for %s"), consumerFpPk.MarshalHex(), opConsumerChainId)
 
 	// wait for consumer FP registration

--- a/itest/opstackl2/op_test_manager.go
+++ b/itest/opstackl2/op_test_manager.go
@@ -4,30 +4,52 @@
 package e2etest_op
 
 import (
+	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
+	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
+	bbncfg "github.com/babylonlabs-io/babylon/client/config"
 	bbncc "github.com/babylonlabs-io/finality-provider/clientcontroller/babylon"
+	opcc "github.com/babylonlabs-io/finality-provider/clientcontroller/opstackl2"
+	cwclient "github.com/babylonlabs-io/finality-provider/cosmwasmclient/client"
 	eotsconfig "github.com/babylonlabs-io/finality-provider/eotsmanager/config"
 	fpcfg "github.com/babylonlabs-io/finality-provider/finality-provider/config"
+	"github.com/babylonlabs-io/finality-provider/finality-provider/service"
 	e2eutils "github.com/babylonlabs-io/finality-provider/itest"
 	base_test_manager "github.com/babylonlabs-io/finality-provider/itest/test-manager"
 	"github.com/babylonlabs-io/finality-provider/metrics"
 	"github.com/babylonlabs-io/finality-provider/testutil/log"
 	"github.com/babylonlabs-io/finality-provider/types"
+	sdkquerytypes "github.com/cosmos/cosmos-sdk/types/query"
 	"github.com/decred/dcrd/dcrec/secp256k1/v4"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
 
+const (
+	opFinalityGadgetContractPath = "../bytecode/op_finality_gadget_16f6154.wasm"
+	opConsumerChainId            = "op-stack-l2-706114"
+	bbnAddrTopUpAmount           = 100000000
+)
+
 type BaseTestManager = base_test_manager.BaseTestManager
 
 type OpL2ConsumerTestManager struct {
 	BaseTestManager
-	BaseDir        string
-	BabylonHandler *e2eutils.BabylonNodeHandler
+	BaseDir              string
+	BabylonHandler       *e2eutils.BabylonNodeHandler
+	OpConsumerController *opcc.OPStackL2ConsumerController
+}
+
+// Config is the config of the OP finality gadget cw contract
+// It will be removed by the final PR
+type Config struct {
+	ConsumerId string `json:"consumer_id"`
 }
 
 // - start Babylon node and wait for it starts
@@ -48,14 +70,42 @@ func StartOpL2ConsumerManager(t *testing.T) *OpL2ConsumerTestManager {
 	// wait for Babylon node starts b/c we will fund the FP address with babylon node
 	babylonController, stakingParams := waitForBabylonNodeStart(t, testDir, logger, babylonHandler)
 
+	// register consumer chain to Babylon
+	_, err = babylonController.RegisterConsumerChain(
+		opConsumerChainId,
+		"OP consumer chain",
+		"Some description about the chain",
+	)
+	require.NoError(t, err)
+	t.Logf(log.Prefix("Register consumer %s to Babylon"), opConsumerChainId)
+
+	// create cosmwasm client
+	// consumer FP config will be defined and updated later
+	_, opConsumerCfg := createConsumerFpConfig(t, testDir, babylonHandler)
+	cwConfig := opConsumerCfg.ToCosmwasmConfig()
+	cwClient, err := opcc.NewCwClient(&cwConfig, logger)
+	require.NoError(t, err)
+
+	// deploy finality gadget cw contract
+	opFinalityGadgetAddress := deployCwContract(t, cwClient)
+	t.Logf(log.Prefix("op-finality-gadget contract address: %s"), opFinalityGadgetAddress)
+
+	// update opConsumerCfg with opFinalityGadgetAddress
+	opConsumerCfg.OPFinalityGadgetAddress = opFinalityGadgetAddress
+
+	// create op consumer controller
+	opConsumerController, err := opcc.NewOPStackL2ConsumerController(opConsumerCfg, logger)
+	require.NoError(t, err)
+
 	ctm := &OpL2ConsumerTestManager{
 		BaseTestManager: BaseTestManager{
 			BBNClient:        babylonController,
 			CovenantPrivKeys: covenantPrivKeys,
 			StakingParams:    stakingParams,
 		},
-		BaseDir:        testDir,
-		BabylonHandler: babylonHandler,
+		BaseDir:              testDir,
+		BabylonHandler:       babylonHandler,
+		OpConsumerController: opConsumerController,
 	}
 
 	return ctm
@@ -116,6 +166,116 @@ func createBabylonFpConfig(
 		eotsconfig.DefaultRPCPort,
 	)
 	return cfg
+}
+
+func createConsumerFpConfig(
+	t *testing.T,
+	testDir string,
+	bh *e2eutils.BabylonNodeHandler,
+) (*fpcfg.Config, *fpcfg.OPStackL2Config) {
+	fpHomeDir := filepath.Join(testDir, "consumer-fp-home")
+	t.Logf(log.Prefix("Consumer FP home dir: %s"), fpHomeDir)
+
+	cfg := e2eutils.DefaultFpConfigWithPorts(
+		fpHomeDir,
+		fpHomeDir,
+		fpcfg.DefaultRPCPort+1,
+		metrics.DefaultFpConfig().Port+1,
+		eotsconfig.DefaultRPCPort+1,
+	)
+
+	// create consumer FP key/address
+	fpBbnKeyInfo, err := service.CreateChainKey(
+		cfg.BabylonConfig.KeyDirectory,
+		cfg.BabylonConfig.ChainID,
+		cfg.BabylonConfig.Key,
+		cfg.BabylonConfig.KeyringBackend,
+		e2eutils.Passphrase,
+		e2eutils.HdPath,
+		"",
+	)
+	require.NoError(t, err)
+
+	// fund the consumer FP address
+	t.Logf(log.Prefix("Funding %dubbn to %s"), bbnAddrTopUpAmount, fpBbnKeyInfo.AccAddress.String())
+	err = bh.BabylonNode.TxBankSend(
+		fpBbnKeyInfo.AccAddress.String(),
+		fmt.Sprintf("%dubbn", bbnAddrTopUpAmount),
+	)
+	require.NoError(t, err)
+
+	// check consumer FP address balance
+	require.Eventually(t, func() bool {
+		balance, err := bh.BabylonNode.CheckAddrBalance(fpBbnKeyInfo.AccAddress.String())
+		if err != nil {
+			t.Logf("Error checking balance: %v", err)
+			return false
+		}
+		return balance == bbnAddrTopUpAmount
+	}, 30*time.Second, 2*time.Second, fmt.Sprintf("failed to top up %s", fpBbnKeyInfo.AccAddress.String()))
+	t.Logf(log.Prefix("Sent %dubbn to %s"), bbnAddrTopUpAmount, fpBbnKeyInfo.AccAddress.String())
+
+	// set consumer FP config
+	dc := bbncfg.DefaultBabylonConfig()
+	opConsumerCfg := &fpcfg.OPStackL2Config{
+		// it will be updated later
+		OPFinalityGadgetAddress: "",
+		// it must be a dialable RPC address checked by NewOPStackL2ConsumerController
+		OPStackL2RPCAddress: "https://optimism-sepolia.drpc.org",
+		// the value does not matter for the test
+		BabylonFinalityGadgetRpc: "127.0.0.1:50051",
+		Key:                      cfg.BabylonConfig.Key,
+		ChainID:                  dc.ChainID,
+		RPCAddr:                  dc.RPCAddr,
+		GRPCAddr:                 dc.GRPCAddr,
+		AccountPrefix:            dc.AccountPrefix,
+		KeyringBackend:           dc.KeyringBackend,
+		KeyDirectory:             cfg.BabylonConfig.KeyDirectory,
+		GasAdjustment:            1.5,
+		GasPrices:                "0.002ubbn",
+		Debug:                    dc.Debug,
+		Timeout:                  dc.Timeout,
+		BlockTimeout:             1 * time.Minute,
+		OutputFormat:             dc.OutputFormat,
+		SignModeStr:              dc.SignModeStr,
+	}
+	cfg.OPStackL2Config = opConsumerCfg
+	return cfg, opConsumerCfg
+}
+
+func deployCwContract(t *testing.T, cwClient *cwclient.Client) string {
+	// store op-finality-gadget contract
+	err := cwClient.StoreWasmCode(opFinalityGadgetContractPath)
+	require.NoError(t, err)
+
+	var codeId uint64
+	require.Eventually(t, func() bool {
+		codeId, _ = cwClient.GetLatestCodeId()
+		return codeId > 0
+	}, e2eutils.EventuallyWaitTimeOut, e2eutils.EventuallyPollTime)
+	require.Equal(t, uint64(1), codeId, "first deployed contract code_id should be 1")
+
+	// instantiate op contract with FG disabled
+	opFinalityGadgetInitMsg := map[string]interface{}{
+		"admin":       cwClient.MustGetAddr(),
+		"consumer_id": opConsumerChainId,
+		"is_enabled":  false,
+	}
+	opFinalityGadgetInitMsgBytes, err := json.Marshal(opFinalityGadgetInitMsg)
+	require.NoError(t, err)
+	err = cwClient.InstantiateContract(codeId, opFinalityGadgetInitMsgBytes)
+	require.NoError(t, err)
+
+	var listContractsResponse *wasmtypes.QueryContractsByCodeResponse
+	require.Eventually(t, func() bool {
+		listContractsResponse, err = cwClient.ListContractsByCode(
+			codeId,
+			&sdkquerytypes.PageRequest{},
+		)
+		return err == nil
+	}, e2eutils.EventuallyWaitTimeOut, e2eutils.EventuallyPollTime)
+	require.Len(t, listContractsResponse.Contracts, 1)
+	return listContractsResponse.Contracts[0]
 }
 
 func (ctm *OpL2ConsumerTestManager) Stop(t *testing.T) {

--- a/itest/test-manager/base_test_manager.go
+++ b/itest/test-manager/base_test_manager.go
@@ -2,10 +2,13 @@ package test_manager
 
 import (
 	"encoding/hex"
+	"fmt"
 	"math/rand"
+	"path/filepath"
 	"testing"
 	"time"
 
+	sdkmath "cosmossdk.io/math"
 	"github.com/babylonlabs-io/babylon/btcstaking"
 	txformat "github.com/babylonlabs-io/babylon/btctxformatter"
 	asig "github.com/babylonlabs-io/babylon/crypto/schnorr-adaptor-signature"
@@ -15,17 +18,24 @@ import (
 	btclctypes "github.com/babylonlabs-io/babylon/x/btclightclient/types"
 	bstypes "github.com/babylonlabs-io/babylon/x/btcstaking/types"
 	ckpttypes "github.com/babylonlabs-io/babylon/x/checkpointing/types"
+	"github.com/babylonlabs-io/finality-provider/clientcontroller/api"
+	bbncc "github.com/babylonlabs-io/finality-provider/clientcontroller/babylon"
+	"github.com/babylonlabs-io/finality-provider/eotsmanager/client"
+	eotsclient "github.com/babylonlabs-io/finality-provider/eotsmanager/client"
+	eotsconfig "github.com/babylonlabs-io/finality-provider/eotsmanager/config"
+	fpcfg "github.com/babylonlabs-io/finality-provider/finality-provider/config"
+	"github.com/babylonlabs-io/finality-provider/finality-provider/service"
 	e2eutils "github.com/babylonlabs-io/finality-provider/itest"
+	"github.com/babylonlabs-io/finality-provider/metrics"
+	"github.com/babylonlabs-io/finality-provider/types"
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/wire"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkquerytypes "github.com/cosmos/cosmos-sdk/types/query"
+	"github.com/lightningnetwork/lnd/signal"
 	"github.com/stretchr/testify/require"
-
-	bbncc "github.com/babylonlabs-io/finality-provider/clientcontroller/babylon"
-	"github.com/babylonlabs-io/finality-provider/finality-provider/service"
-	"github.com/babylonlabs-io/finality-provider/types"
+	"go.uber.org/zap"
 )
 
 type BaseTestManager struct {
@@ -532,4 +542,95 @@ func (tm *BaseTestManager) FinalizeUntilEpoch(t *testing.T, epoch uint64) {
 	}, e2eutils.EventuallyWaitTimeOut, e2eutils.EventuallyPollTime)
 
 	t.Logf("epoch %d is finalised", epoch)
+}
+
+func StartEotsManagers(
+	t *testing.T,
+	logger *zap.Logger,
+	testDir string,
+	babylonFpCfg *fpcfg.Config,
+	consumerFpCfg *fpcfg.Config,
+	shutdownInterceptor *signal.Interceptor,
+) (*e2eutils.EOTSServerHandler, []*eotsclient.EOTSManagerGRpcClient) {
+	fpCfgs := []*fpcfg.Config{babylonFpCfg, consumerFpCfg}
+	eotsClients := make([]*eotsclient.EOTSManagerGRpcClient, len(fpCfgs))
+	eotsHomeDirs := []string{filepath.Join(testDir, "babylon-eots-home"), filepath.Join(testDir, "consumer-eots-home")}
+	eotsConfigs := make([]*eotsconfig.Config, len(fpCfgs))
+	for i := 0; i < len(fpCfgs); i++ {
+		eotsCfg := eotsconfig.DefaultConfigWithHomePathAndPorts(
+			eotsHomeDirs[i],
+			eotsconfig.DefaultRPCPort+i,
+			metrics.DefaultEotsConfig().Port+i,
+		)
+		eotsConfigs[i] = eotsCfg
+	}
+
+	eh := e2eutils.NewEOTSServerHandlerMultiFP(t, logger, eotsConfigs, eotsHomeDirs, shutdownInterceptor)
+	eh.Start()
+
+	// create EOTS clients
+	for i := 0; i < len(fpCfgs); i++ {
+		// wait for EOTS servers to start
+		// see https://github.com/babylonchain/finality-provider/pull/517
+		var eotsCli *eotsclient.EOTSManagerGRpcClient
+		var err error
+		require.Eventually(t, func() bool {
+			eotsCli, err = eotsclient.NewEOTSManagerGRpcClient(fpCfgs[i].EOTSManagerAddress)
+			if err != nil {
+				t.Logf("Error creating EOTS client: %v", err)
+				return false
+			}
+			eotsClients[i] = eotsCli
+			return true
+		}, 5*time.Second, time.Second, "Failed to create EOTS client")
+	}
+	return eh, eotsClients
+}
+
+func CreateAndStartFpApp(
+	t *testing.T,
+	logger *zap.Logger,
+	cfg *fpcfg.Config,
+	cc api.ConsumerController,
+	eotsCli *client.EOTSManagerGRpcClient,
+) *service.FinalityProviderApp {
+	bc, err := bbncc.NewBabylonController(cfg.BabylonConfig, &cfg.BTCNetParams, logger)
+	require.NoError(t, err)
+
+	fpdb, err := cfg.DatabaseConfig.GetDbBackend()
+	require.NoError(t, err)
+
+	fpApp, err := service.NewFinalityProviderApp(cfg, bc, cc, eotsCli, fpdb, logger)
+	require.NoError(t, err)
+
+	err = fpApp.Start()
+	require.NoError(t, err)
+
+	return fpApp
+}
+
+func CreateAndRegisterFinalityProvider(t *testing.T, fpApp *service.FinalityProviderApp, chainId string) *bbntypes.BIP340PubKey {
+	fpCfg := fpApp.GetConfig()
+	keyName := fpCfg.BabylonConfig.Key
+	moniker := fmt.Sprintf("%s-%s", chainId, e2eutils.MonikerPrefix)
+	commission := sdkmath.LegacyZeroDec()
+	desc := e2eutils.NewDescription(moniker)
+
+	res, err := fpApp.CreateFinalityProvider(
+		keyName,
+		chainId,
+		e2eutils.Passphrase,
+		e2eutils.HdPath,
+		nil,
+		desc,
+		&commission,
+	)
+	require.NoError(t, err)
+
+	fpPk, err := bbntypes.NewBIP340PubKeyFromHex(res.FpInfo.BtcPkHex)
+	require.NoError(t, err)
+
+	_, err = fpApp.RegisterFinalityProvider(fpPk.MarshalHex())
+	require.NoError(t, err)
+	return fpPk
 }


### PR DESCRIPTION
## Summary

This is the third refactor https://github.com/babylonlabs-io/finality-provider/pull/178 PR to implement the basic setup for FP registration and BTC delegation.

## Test Plan

```
make lint
make test-e2e-op

...
    op_test_manager.go:412: [13:38:17.854] Registered Finality Provider 6306502a53110350adfebcacfdc25f66ab14fbe27d41f7661163a53d1f3c43a3 for chain-test
2024-12-03T13:38:18.414+0800    INFO    eotsmanager/localmanager.go:136 successfully created an EOTS key        {"key name": "test-spending-key", "pk": "d442e852dd78b732da94cc45a92bfd7667cbd36d16e0a028d173523727cc9dc5"}
2024-12-03T13:38:18.464+0800    INFO    service/app.go:444      successfully created a finality-provider        {"btc_pk": "d442e852dd78b732da94cc45a92bfd7667cbd36d16e0a028d173523727cc9dc5", "addr": "bbn1ga49xpmsenrf5ar835kacngl4cww85t97q9fyj", "key_name": "test-spending-key"}
2024-12-03T13:38:22.947+0800    INFO    service/app.go:653      successfully registered finality-provider on babylon    {"btc_pk": "d442e852dd78b732da94cc45a92bfd7667cbd36d16e0a028d173523727cc9dc5", "fp_addr": "bbn1ga49xpmsenrf5ar835kacngl4cww85t97q9fyj", "txHash": "84D2043905E9797EFFDBBA658ACFB8D2DC5380734FDCD5E105C8AEEA2CA6CDBA"}
2024-12-03T13:38:22.947+0800    INFO    cosmos/log.go:131       Successful transaction  {"chain_id": "chain-test", "gas_used": 81026, "fees": "2477ubbn", "fee_payer": "GjS\u0007p\ufffdƚtg\ufffd-\ufffdM\u001f\ufffd\u001c\ufffd\ufffde", "height": 7, "msg_types": ["/babylon.btcstaking.v1.MsgCreateFinalityProvider"], "tx_hash": "84D2043905E9797EFFDBBA658ACFB8D2DC5380734FDCD5E105C8AEEA2CA6CDBA"}
    op_test_manager.go:422: [13:38:22.995] Registered Finality Provider d442e852dd78b732da94cc45a92bfd7667cbd36d16e0a028d173523727cc9dc5 for op-stack-l2-706114
2024-12-03T13:38:28.080+0800    INFO    cosmos/log.go:131       Successful transaction  {"chain_id": "chain-test", "gas_used": 141398, "fees": "4887ubbn", "fee_payer": "\ufffd\ufffd\u001ea\ufffd3ׁ5ޙ\ufffdl\ufffd#\ufffd\ufffd7\ufffd\ufffd", "height": 8, "msg_types": ["/babylon.btclightclient.v1.MsgInsertHeaders"], "tx_hash": "14AC6CCD05208D0311337B8066CE5810C8720E281EDFC1B8C9E6C558EA9F5605"}
    base_test_manager.go:175: successfully submitted a BTC delegation
2024-12-03T13:38:33.160+0800    INFO    cosmos/log.go:131       Successful transaction  {"chain_id": "chain-test", "gas_used": 130770, "fees": "4461ubbn", "fee_payer": "\ufffd\ufffd\u001ea\ufffd3ׁ5ޙ\ufffdl\ufffd#\ufffd\ufffd7\ufffd\ufffd", "height": 9, "msg_types": ["/babylon.btcstaking.v1.MsgCreateBTCDelegation"], "tx_hash": "43A7A084550C188FB0DF69582563F0D58DCEB25FBA5EF326DF8088ED7565A0AF"}
    base_test_manager.go:206: delegations are pending
2024-12-03T13:38:38.358+0800    INFO    cosmos/log.go:131       Successful transaction  {"chain_id": "chain-test", "gas_used": 113166, "fees": "3758ubbn", "fee_payer": "\ufffd\ufffd\u001ea\ufffd3ׁ5ޙ\ufffdl\ufffd#\ufffd\ufffd7\ufffd\ufffd", "height": 10, "msg_types": ["/babylon.btcstaking.v1.MsgAddCovenantSigs"], "tx_hash": "0CD574F8CABE1FAECA396C6C4D3B25B0FF0CC91C6B18090CF9E5535E1557C4A9"}
2024-12-03T13:38:43.465+0800    INFO    cosmos/log.go:131       Successful transaction  {"chain_id": "chain-test", "gas_used": 203766, "fees": "7381ubbn", "fee_payer": "\ufffd\ufffd\u001ea\ufffd3ׁ5ޙ\ufffdl\ufffd#\ufffd\ufffd7\ufffd\ufffd", "height": 11, "msg_types": ["/babylon.btcstaking.v1.MsgAddCovenantSigs"], "tx_hash": "5A65F9BED82DC6514C5B4E33292DCCD7BFF66AE3B17D37676417D300CC4687CD"}
    base_test_manager.go:226: delegations are active
```