### PR TITLE
chore: refactor op e2e tests - part 4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,16 +125,6 @@ test-e2e-op-ci: clean-e2e install-babylond
 	"xargs go test -race -mod=readonly -timeout=25m -v $(PACKAGES_E2E_OP) -count=1 --tags=e2e_op --run" \
 	--split-by=name --timings-type=name
 
-DEVNET_REPO_URL := https://github.com/babylonlabs-io/op-e2e-devnet
-TARGET_DIR := ./itest/opstackl2/devnet-data
-
-.PHONY: op-e2e-devnet
-op-e2e-devnet:
-	@rm -rf $(TARGET_DIR)
-	@mkdir -p $(TARGET_DIR)
-	@git clone $(DEVNET_REPO_URL) $(TARGET_DIR)
-	@echo "Devnet data downloaded to $(TARGET_DIR)"
-
 ###############################################################################
 ###                                Protobuf                                 ###
 ###############################################################################

--- a/finality-provider/service/app.go
+++ b/finality-provider/service/app.go
@@ -332,6 +332,24 @@ func (app *FinalityProviderApp) Start() error {
 	return startErr
 }
 
+// StartWithoutSyncFpStatus starts only the finality-provider daemon without any finality-provider instances
+// and without syncing the finality-provider status loop for testing purpose
+// b/c this loop detects FP status and then automatically starts the FP instance when it is ACTIVE
+// Note: this is only for testing purposes
+func (app *FinalityProviderApp) StartWithoutSyncFpStatus() error {
+	var startErr error
+	app.startOnce.Do(func() {
+		app.logger.Info("Starting FinalityProviderApp")
+
+		app.wg.Add(3)
+		go app.eventLoop()
+		go app.registrationLoop()
+		go app.metricsUpdateLoop()
+	})
+
+	return startErr
+}
+
 func (app *FinalityProviderApp) Stop() error {
 	var stopErr error
 	app.stopOnce.Do(func() {

--- a/itest/opstackl2/README.md
+++ b/itest/opstackl2/README.md
@@ -1,19 +1,11 @@
 # OP-stack itest
 
-To run the e2e tests, first you need to set up the devnet data:
+Run the following command to start the e2e tests:
 
 ```bash
-$ make op-e2e-devnet
-```
-
-Then run the following command to start the e2e tests:
-
-```bash
-$ make test-e2e-op
-
 # Run all tests
-$ make test-e2e-op
+make test-e2e-op
 
 # Filter specific test
-$ make test-e2e-op-filter FILTER=TestFinalityGadget
+make test-e2e-op-filter FILTER=TestPubRandCommitment
 ```

--- a/itest/opstackl2/op_e2e_test.go
+++ b/itest/opstackl2/op_e2e_test.go
@@ -4,11 +4,52 @@
 package e2etest_op
 
 import (
+	"encoding/json"
 	"testing"
+
+	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
+	opcc "github.com/babylonlabs-io/finality-provider/clientcontroller/opstackl2"
+	e2eutils "github.com/babylonlabs-io/finality-provider/itest"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
 
 // This test case will be removed by the final PR
 func TestOpTestManagerSetup(t *testing.T) {
 	ctm := StartOpL2ConsumerManager(t)
 	defer ctm.Stop(t)
+
+	// setup logger
+	config := zap.NewDevelopmentConfig()
+	config.Level = zap.NewAtomicLevelAt(zapcore.Level(zap.DebugLevel))
+	logger, err := config.Build()
+	require.NoError(t, err)
+
+	// create cosmwasm client
+	cwConfig := ctm.OpConsumerController.Cfg.ToCosmwasmConfig()
+	cwClient, err := opcc.NewCwClient(&cwConfig, logger)
+	require.NoError(t, err)
+
+	// query cw contract config
+	queryMsg := map[string]interface{}{
+		"config": struct{}{},
+	}
+	queryMsgBytes, err := json.Marshal(queryMsg)
+	require.NoError(t, err)
+
+	var queryConfigResponse *wasmtypes.QuerySmartContractStateResponse
+	require.Eventually(t, func() bool {
+		queryConfigResponse, err = cwClient.QuerySmartContractState(
+			ctm.OpConsumerController.Cfg.OPFinalityGadgetAddress,
+			string(queryMsgBytes),
+		)
+		return err == nil
+	}, e2eutils.EventuallyWaitTimeOut, e2eutils.EventuallyPollTime)
+
+	var cfgResp Config
+	err = json.Unmarshal(queryConfigResponse.Data, &cfgResp)
+	require.NoError(t, err)
+	t.Logf("Response config query from CW contract: %+v", cfgResp)
+	require.Equal(t, opConsumerChainId, cfgResp.ConsumerId)
 }

--- a/itest/opstackl2/op_e2e_test.go
+++ b/itest/opstackl2/op_e2e_test.go
@@ -5,10 +5,14 @@ package e2etest_op
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
-// This test case will be removed by the final PR
-func TestOpTestManagerSetup(t *testing.T) {
+// TestPubRandCommitment tests the consumer controller's functions:
+// - CommitPubRandList
+// - QueryLastPublicRandCommit
+func TestPubRandCommitment(t *testing.T) {
 	ctm := StartOpL2ConsumerManager(t)
 	defer ctm.Stop(t)
 
@@ -16,5 +20,23 @@ func TestOpTestManagerSetup(t *testing.T) {
 	fps := ctm.setupBabylonAndConsumerFp(t)
 
 	// send a BTC delegation and wait for activation
-	ctm.delegateBTCAndWaitForActivation(t, fps[0], fps[1])
+	consumerFpPk := fps[1]
+	ctm.delegateBTCAndWaitForActivation(t, fps[0], consumerFpPk)
+
+	// get the consumer FP instance
+	consumerFpInstance := ctm.getConsumerFpInstance(t, consumerFpPk)
+
+	// commit pub rand with start height 1
+	// this will call consumer controller's CommitPubRandList function
+	_, err := consumerFpInstance.CommitPubRand(1)
+	require.NoError(t, err)
+
+	// query the last pub rand
+	pubRand, err := ctm.OpConsumerController.QueryLastPublicRandCommit(consumerFpPk.MustToBTCPK())
+	require.NoError(t, err)
+	require.NotNil(t, pubRand)
+
+	// check the end height of the pub rand
+	consumerCfg := ctm.ConsumerFpApp.GetConfig()
+	require.Equal(t, uint64(consumerCfg.NumPubRand), pubRand.EndHeight())
 }

--- a/itest/opstackl2/op_e2e_test.go
+++ b/itest/opstackl2/op_e2e_test.go
@@ -4,15 +4,7 @@
 package e2etest_op
 
 import (
-	"encoding/json"
 	"testing"
-
-	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
-	opcc "github.com/babylonlabs-io/finality-provider/clientcontroller/opstackl2"
-	e2eutils "github.com/babylonlabs-io/finality-provider/itest"
-	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 )
 
 // This test case will be removed by the final PR
@@ -20,36 +12,9 @@ func TestOpTestManagerSetup(t *testing.T) {
 	ctm := StartOpL2ConsumerManager(t)
 	defer ctm.Stop(t)
 
-	// setup logger
-	config := zap.NewDevelopmentConfig()
-	config.Level = zap.NewAtomicLevelAt(zapcore.Level(zap.DebugLevel))
-	logger, err := config.Build()
-	require.NoError(t, err)
+	// create and register Babylon FP and OP consumer FP
+	fps := ctm.setupBabylonAndConsumerFp(t)
 
-	// create cosmwasm client
-	cwConfig := ctm.OpConsumerController.Cfg.ToCosmwasmConfig()
-	cwClient, err := opcc.NewCwClient(&cwConfig, logger)
-	require.NoError(t, err)
-
-	// query cw contract config
-	queryMsg := map[string]interface{}{
-		"config": struct{}{},
-	}
-	queryMsgBytes, err := json.Marshal(queryMsg)
-	require.NoError(t, err)
-
-	var queryConfigResponse *wasmtypes.QuerySmartContractStateResponse
-	require.Eventually(t, func() bool {
-		queryConfigResponse, err = cwClient.QuerySmartContractState(
-			ctm.OpConsumerController.Cfg.OPFinalityGadgetAddress,
-			string(queryMsgBytes),
-		)
-		return err == nil
-	}, e2eutils.EventuallyWaitTimeOut, e2eutils.EventuallyPollTime)
-
-	var cfgResp Config
-	err = json.Unmarshal(queryConfigResponse.Data, &cfgResp)
-	require.NoError(t, err)
-	t.Logf("Response config query from CW contract: %+v", cfgResp)
-	require.Equal(t, opConsumerChainId, cfgResp.ConsumerId)
+	// send a BTC delegation and wait for activation
+	ctm.delegateBTCAndWaitForActivation(t, fps[0], fps[1])
 }

--- a/itest/opstackl2/op_test_manager.go
+++ b/itest/opstackl2/op_test_manager.go
@@ -4,30 +4,52 @@
 package e2etest_op
 
 import (
+	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
+	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
+	bbncfg "github.com/babylonlabs-io/babylon/client/config"
 	bbncc "github.com/babylonlabs-io/finality-provider/clientcontroller/babylon"
+	opcc "github.com/babylonlabs-io/finality-provider/clientcontroller/opstackl2"
+	cwclient "github.com/babylonlabs-io/finality-provider/cosmwasmclient/client"
 	eotsconfig "github.com/babylonlabs-io/finality-provider/eotsmanager/config"
 	fpcfg "github.com/babylonlabs-io/finality-provider/finality-provider/config"
+	"github.com/babylonlabs-io/finality-provider/finality-provider/service"
 	e2eutils "github.com/babylonlabs-io/finality-provider/itest"
 	base_test_manager "github.com/babylonlabs-io/finality-provider/itest/test-manager"
 	"github.com/babylonlabs-io/finality-provider/metrics"
 	"github.com/babylonlabs-io/finality-provider/testutil/log"
 	"github.com/babylonlabs-io/finality-provider/types"
+	sdkquerytypes "github.com/cosmos/cosmos-sdk/types/query"
 	"github.com/decred/dcrd/dcrec/secp256k1/v4"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
 
+const (
+	opFinalityGadgetContractPath = "../bytecode/op_finality_gadget_16f6154.wasm"
+	opConsumerChainId            = "op-stack-l2-706114"
+	bbnAddrTopUpAmount           = 100000000
+)
+
 type BaseTestManager = base_test_manager.BaseTestManager
 
 type OpL2ConsumerTestManager struct {
 	BaseTestManager
-	BaseDir        string
-	BabylonHandler *e2eutils.BabylonNodeHandler
+	BaseDir              string
+	BabylonHandler       *e2eutils.BabylonNodeHandler
+	OpConsumerController *opcc.OPStackL2ConsumerController
+}
+
+// Config is the config of the OP finality gadget cw contract
+// It will be removed by the final PR
+type Config struct {
+	ConsumerId string `json:"consumer_id"`
 }
 
 // - start Babylon node and wait for it starts
@@ -48,14 +70,42 @@ func StartOpL2ConsumerManager(t *testing.T) *OpL2ConsumerTestManager {
 	// wait for Babylon node starts b/c we will fund the FP address with babylon node
 	babylonController, stakingParams := waitForBabylonNodeStart(t, testDir, logger, babylonHandler)
 
+	// register consumer chain to Babylon
+	_, err = babylonController.RegisterConsumerChain(
+		opConsumerChainId,
+		"OP consumer chain",
+		"Some description about the chain",
+	)
+	require.NoError(t, err)
+	t.Logf(log.Prefix("Register consumer %s to Babylon"), opConsumerChainId)
+
+	// create cosmwasm client
+	// consumer FP config will be defined and updated later
+	_, opConsumerCfg := createConsumerFpConfig(t, testDir, babylonHandler)
+	cwConfig := opConsumerCfg.ToCosmwasmConfig()
+	cwClient, err := opcc.NewCwClient(&cwConfig, logger)
+	require.NoError(t, err)
+
+	// deploy finality gadget cw contract
+	opFinalityGadgetAddress := deployCwContract(t, cwClient)
+	t.Logf(log.Prefix("op-finality-gadget contract address: %s"), opFinalityGadgetAddress)
+
+	// update opConsumerCfg with opFinalityGadgetAddress
+	opConsumerCfg.OPFinalityGadgetAddress = opFinalityGadgetAddress
+
+	// create op consumer controller
+	opConsumerController, err := opcc.NewOPStackL2ConsumerController(opConsumerCfg, logger)
+	require.NoError(t, err)
+
 	ctm := &OpL2ConsumerTestManager{
 		BaseTestManager: BaseTestManager{
 			BBNClient:        babylonController,
 			CovenantPrivKeys: covenantPrivKeys,
 			StakingParams:    stakingParams,
 		},
-		BaseDir:        testDir,
-		BabylonHandler: babylonHandler,
+		BaseDir:              testDir,
+		BabylonHandler:       babylonHandler,
+		OpConsumerController: opConsumerController,
 	}
 
 	return ctm
@@ -116,6 +166,116 @@ func createBabylonFpConfig(
 		eotsconfig.DefaultRPCPort,
 	)
 	return cfg
+}
+
+func createConsumerFpConfig(
+	t *testing.T,
+	testDir string,
+	bh *e2eutils.BabylonNodeHandler,
+) (*fpcfg.Config, *fpcfg.OPStackL2Config) {
+	fpHomeDir := filepath.Join(testDir, "consumer-fp-home")
+	t.Logf(log.Prefix("Consumer FP home dir: %s"), fpHomeDir)
+
+	cfg := e2eutils.DefaultFpConfigWithPorts(
+		fpHomeDir,
+		fpHomeDir,
+		fpcfg.DefaultRPCPort+1,
+		metrics.DefaultFpConfig().Port+1,
+		eotsconfig.DefaultRPCPort+1,
+	)
+
+	// create consumer FP key/address
+	fpBbnKeyInfo, err := service.CreateChainKey(
+		cfg.BabylonConfig.KeyDirectory,
+		cfg.BabylonConfig.ChainID,
+		cfg.BabylonConfig.Key,
+		cfg.BabylonConfig.KeyringBackend,
+		e2eutils.Passphrase,
+		e2eutils.HdPath,
+		"",
+	)
+	require.NoError(t, err)
+
+	// fund the consumer FP address
+	t.Logf(log.Prefix("Funding %dubbn to %s"), bbnAddrTopUpAmount, fpBbnKeyInfo.AccAddress.String())
+	err = bh.BabylonNode.TxBankSend(
+		fpBbnKeyInfo.AccAddress.String(),
+		fmt.Sprintf("%dubbn", bbnAddrTopUpAmount),
+	)
+	require.NoError(t, err)
+
+	// check consumer FP address balance
+	require.Eventually(t, func() bool {
+		balance, err := bh.BabylonNode.CheckAddrBalance(fpBbnKeyInfo.AccAddress.String())
+		if err != nil {
+			t.Logf("Error checking balance: %v", err)
+			return false
+		}
+		return balance == bbnAddrTopUpAmount
+	}, 30*time.Second, 2*time.Second, fmt.Sprintf("failed to top up %s", fpBbnKeyInfo.AccAddress.String()))
+	t.Logf(log.Prefix("Sent %dubbn to %s"), bbnAddrTopUpAmount, fpBbnKeyInfo.AccAddress.String())
+
+	// set consumer FP config
+	dc := bbncfg.DefaultBabylonConfig()
+	opConsumerCfg := &fpcfg.OPStackL2Config{
+		// it will be updated later
+		OPFinalityGadgetAddress: "",
+		// it must be a dialable RPC address checked by NewOPStackL2ConsumerController
+		OPStackL2RPCAddress: "https://optimism-sepolia.drpc.org",
+		// the value does not matter for the test
+		BabylonFinalityGadgetRpc: "127.0.0.1:50051",
+		Key:                      cfg.BabylonConfig.Key,
+		ChainID:                  dc.ChainID,
+		RPCAddr:                  dc.RPCAddr,
+		GRPCAddr:                 dc.GRPCAddr,
+		AccountPrefix:            dc.AccountPrefix,
+		KeyringBackend:           dc.KeyringBackend,
+		KeyDirectory:             cfg.BabylonConfig.KeyDirectory,
+		GasAdjustment:            1.5,
+		GasPrices:                "0.002ubbn",
+		Debug:                    dc.Debug,
+		Timeout:                  dc.Timeout,
+		BlockTimeout:             1 * time.Minute,
+		OutputFormat:             dc.OutputFormat,
+		SignModeStr:              dc.SignModeStr,
+	}
+	cfg.OPStackL2Config = opConsumerCfg
+	return cfg, opConsumerCfg
+}
+
+func deployCwContract(t *testing.T, cwClient *cwclient.Client) string {
+	// store op-finality-gadget contract
+	err := cwClient.StoreWasmCode(opFinalityGadgetContractPath)
+	require.NoError(t, err)
+
+	var codeId uint64
+	require.Eventually(t, func() bool {
+		codeId, _ = cwClient.GetLatestCodeId()
+		return codeId > 0
+	}, e2eutils.EventuallyWaitTimeOut, e2eutils.EventuallyPollTime)
+	require.Equal(t, uint64(1), codeId, "first deployed contract code_id should be 1")
+
+	// instantiate op contract with FG disabled
+	opFinalityGadgetInitMsg := map[string]interface{}{
+		"admin":       cwClient.MustGetAddr(),
+		"consumer_id": opConsumerChainId,
+		"is_enabled":  false,
+	}
+	opFinalityGadgetInitMsgBytes, err := json.Marshal(opFinalityGadgetInitMsg)
+	require.NoError(t, err)
+	err = cwClient.InstantiateContract(codeId, opFinalityGadgetInitMsgBytes)
+	require.NoError(t, err)
+
+	var listContractsResponse *wasmtypes.QueryContractsByCodeResponse
+	require.Eventually(t, func() bool {
+		listContractsResponse, err = cwClient.ListContractsByCode(
+			codeId,
+			&sdkquerytypes.PageRequest{},
+		)
+		return err == nil
+	}, e2eutils.EventuallyWaitTimeOut, e2eutils.EventuallyPollTime)
+	require.Len(t, listContractsResponse.Contracts, 1)
+	return listContractsResponse.Contracts[0]
 }
 
 func (ctm *OpL2ConsumerTestManager) Stop(t *testing.T) {


### PR DESCRIPTION
## Summary

This PR introduces the OP e2e test case `TestPubRandCommitment` as part of the refactor in https://github.com/babylonlabs-io/finality-provider/pull/178

## Test Plan

```
make lint
make test-e2e-op

2024-12-03T22:01:22.746+0800    INFO    service/app.go:671      successfully registered finality-provider on babylon    {"btc_pk": "812ab3e81b9862ff55af0047966a5a175f7126cb3a17c6f7243d424d5fbe1157", "fp_addr": "bbn1vgk932ehfk2cymc8ppugp5scshmst5ekhlpszp", "txHash": "F106A50CAAAFC66BFCF514533FE9ADF89357727BF31A4EF02A5B02E1788C8BD9"}
    op_test_manager.go:330: [22:01:22.795] Registered Finality Provider 812ab3e81b9862ff55af0047966a5a175f7126cb3a17c6f7243d424d5fbe1157 for op-stack-l2-706114
...
    base_test_manager.go:236: delegations are active
2024-12-03T22:01:48.516+0800    DEBUG   opstackl2/consumer.go:167       Successfully committed public randomness        {"fp_pk_hex": "812ab3e81b9862ff55af0047966a5a175f7126cb3a17c6f7243d424d5fbe1157", "start_height": 1, "num_pub_rand": 1000}
...
--- PASS: TestPubRandCommitment (64.51s)
PASS
ok      github.com/babylonlabs-io/finality-provider/itest/opstackl2     66.234s
```