### PR TITLE
chore: refactor op e2e tests - part 5

### DIFF
--- a/clientcontroller/opstackl2/consumer.go
+++ b/clientcontroller/opstackl2/consumer.go
@@ -202,6 +202,7 @@ func (cc *OPStackL2ConsumerController) SubmitBatchFinalitySigs(
 		return nil, fmt.Errorf("the number of blocks %v should match the number of finality signatures %v", len(blocks), len(sigs))
 	}
 	msgs := make([]sdk.Msg, 0, len(blocks))
+	fpPkHex := bbntypes.NewBIP340PubKeyFromBTCPK(fpPk).MarshalHex()
 	for i, block := range blocks {
 		cmtProof := cmtcrypto.Proof{}
 		if err := cmtProof.Unmarshal(proofList[i]); err != nil {
@@ -210,7 +211,7 @@ func (cc *OPStackL2ConsumerController) SubmitBatchFinalitySigs(
 
 		msg := SubmitFinalitySignatureMsg{
 			SubmitFinalitySignature: SubmitFinalitySignatureMsgParams{
-				FpPubkeyHex: bbntypes.NewBIP340PubKeyFromBTCPK(fpPk).MarshalHex(),
+				FpPubkeyHex: fpPkHex,
 				Height:      block.Height,
 				PubRand:     bbntypes.NewSchnorrPubRandFromFieldVal(pubRandList[i]).MustMarshal(),
 				Proof:       ConvertProof(cmtProof),
@@ -236,6 +237,7 @@ func (cc *OPStackL2ConsumerController) SubmitBatchFinalitySigs(
 	}
 	cc.logger.Debug(
 		"Successfully submitted finality signatures in a batch",
+		zap.String("fp_pk_hex", fpPkHex),
 		zap.Uint64("start_height", blocks[0].Height),
 		zap.Uint64("end_height", blocks[len(blocks)-1].Height),
 	)


### PR DESCRIPTION
## Summary

This PR adds the OP e2e test case `TestFinalitySigSubmission` as part of the refactor in https://github.com/babylonlabs-io/finality-provider/pull/178

## Test Plan

```
make lint
make test-e2e-op-filter FILTER=TestFinalitySigSubmission

    op_test_manager.go:127: [12:48:55.999] Started Consumer FP App
    op_test_manager.go:327: [12:49:03.294] Registered Finality Provider 3f0ed4bbe63cf80afa0830512329bdbc96eed4a318d81bbce68fdf745547a746 for op-stack-l2-706114
    base_test_manager.go:185: successfully submitted a BTC delegation
    base_test_manager.go:236: delegations are active
2024-12-04T12:49:28.892+0800    DEBUG   opstackl2/consumer.go:167       Successfully committed public randomness        {"fp_pk_hex": "3f0ed4bbe63cf80afa0830512329bdbc96eed4a318d81bbce68fdf745547a746", "start_height": 1, "num_pub_rand": 1000}
2024-12-04T12:49:33.931+0800    DEBUG   opstackl2/consumer.go:238       Successfully submitted finality signatures in a batch   {"fp_pk_hex": "3f0ed4bbe63cf80afa0830512329bdbc96eed4a318d81bbce68fdf745547a746", "start_height": 1, "end_height": 3}
    op_test_manager.go:399: Stopping test manager
--- PASS: TestFinalitySigSubmission (70.10s)
PASS
ok      github.com/babylonlabs-io/finality-provider/itest/opstackl2     71.846s
```