### PR TITLE
chore: x/incentive cmds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Bug Fixes
 
 * [#199](https://github.com/babylonlabs-io/finality-provider/pull/199) EOTS signing for multiple finality providers
+* [#203](https://github.com/babylonlabs-io/finality-provider/pull/203) fpd cli: Withdraw rewards and set withdraw addr
+
 
 ## v0.13.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * [#199](https://github.com/babylonlabs-io/finality-provider/pull/199) EOTS signing for multiple finality providers
 * [#203](https://github.com/babylonlabs-io/finality-provider/pull/203) fpd cli: Withdraw rewards and set withdraw addr
 
-
 ## v0.13.0
 
 ### Improvements

--- a/finality-provider/cmd/fpd/daemon/tx.go
+++ b/finality-provider/cmd/fpd/daemon/tx.go
@@ -8,6 +8,8 @@ import (
 	"github.com/spf13/cobra"
 
 	btcstakingcli "github.com/babylonlabs-io/babylon/x/btcstaking/client/cli"
+	incentivecli "github.com/babylonlabs-io/babylon/x/incentive/client/cli"
+
 	btcstakingtypes "github.com/babylonlabs-io/babylon/x/btcstaking/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authclient "github.com/cosmos/cosmos-sdk/x/auth/client"
@@ -28,6 +30,8 @@ func CommandTxs() *cobra.Command {
 		authcli.GetSignCommand(),
 		btcstakingcli.NewCreateFinalityProviderCmd(),
 		NewValidateSignedFinalityProviderCmd(),
+		incentivecli.NewWithdrawRewardCmd(),
+		incentivecli.NewSetWithdrawAddressCmd(),
 	)
 
 	return cmd


### PR DESCRIPTION
Adds support for invoking `NewWithdrawRewardCmd` and `NewSetWithdrawAddressCmd`

[Closes](https://github.com/babylonlabs-io/finality-provider/issues/13)