### PR TITLE
docs: prometheus metrics

### DIFF
--- a/docs/finality-provider-operation.md
+++ b/docs/finality-provider-operation.md
@@ -661,3 +661,7 @@ hex as a label.
 > - Large gaps in `fp_seconds_since_last_vote`
 > - Increasing `fp_total_failed_votes`
 
+For a complete list of available metrics, see:
+- Finality Provider metrics: [fp_collectors.go](../metrics/fp_collectors.go)
+- EOTS metrics: [eots_collectors.go](../metrics/eots_collectors.go)
+


### PR DESCRIPTION
## Summary

For testnet 5 we have the operational transition doc, the prometheus docs needed to be added to this.

closes: https://github.com/babylonlabs-io/finality-provider/issues/170