### PR TITLE
chore: Remove sync fp status loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## Unreleased
 
+### Improvements
+
+* [#208](https://github.com/babylonlabs-io/finality-provider/pull/208) Remove sync fp status loop
+
 ## v0.13.1
 
 ### Bug Fixes

--- a/clientcontroller/babylon.go
+++ b/clientcontroller/babylon.go
@@ -291,7 +291,7 @@ func (bc *BabylonController) QueryFinalityProviderVotingPower(fpPk *btcec.Public
 			return 0, nil
 		}
 
-		return 0, fmt.Errorf("failed to query Finality Voting Power at Height %d: %w", blockHeight, err)
+		return 0, err
 	}
 
 	return res.VotingPower, nil

--- a/finality-provider/config/config.go
+++ b/finality-provider/config/config.go
@@ -32,7 +32,6 @@ const (
 	defaultStatusUpdateInterval        = 20 * time.Second
 	defaultRandomInterval              = 30 * time.Second
 	defaultSubmitRetryInterval         = 1 * time.Second
-	defaultSyncFpStatusInterval        = 30 * time.Second
 	defaultSignatureSubmissionInterval = 1 * time.Second
 	defaultMaxSubmissionRetries        = 20
 	defaultBitcoinNetwork              = "signet"
@@ -65,7 +64,6 @@ type Config struct {
 	StatusUpdateInterval        time.Duration `long:"statusupdateinterval" description:"The interval between each update of finality-provider status"`
 	RandomnessCommitInterval    time.Duration `long:"randomnesscommitinterval" description:"The interval between each attempt to commit public randomness"`
 	SubmissionRetryInterval     time.Duration `long:"submissionretryinterval" description:"The interval between each attempt to submit finality signature or public randomness after a failure"`
-	SyncFpStatusInterval        time.Duration `long:"syncfpstatusinterval" description:"The duration of time that it should sync FP status with the client blockchain"`
 	SignatureSubmissionInterval time.Duration `long:"signaturesubmissioninterval" description:"The interval between each finality signature(s) submission"`
 
 	BitcoinNetwork string `long:"bitcoinnetwork" description:"Bitcoin network to run on" choise:"mainnet" choice:"regtest" choice:"testnet" choice:"simnet" choice:"signet"`
@@ -108,7 +106,6 @@ func DefaultConfigWithHome(homePath string) Config {
 		EOTSManagerAddress:          defaultEOTSManagerAddress,
 		RPCListener:                 DefaultRPCListener,
 		Metrics:                     metrics.DefaultFpConfig(),
-		SyncFpStatusInterval:        defaultSyncFpStatusInterval,
 	}
 
 	if err := cfg.Validate(); err != nil {

--- a/finality-provider/store/fpstore.go
+++ b/finality-provider/store/fpstore.go
@@ -107,6 +107,12 @@ func (s *FinalityProviderStore) SetFpStatus(btcPk *btcec.PublicKey, status proto
 	return s.setFinalityProviderState(btcPk, setFpStatus)
 }
 
+func (s *FinalityProviderStore) MustSetFpStatus(btcPk *btcec.PublicKey, status proto.FinalityProviderStatus) {
+	if err := s.SetFpStatus(btcPk, status); err != nil {
+		panic(err)
+	}
+}
+
 // UpdateFpStatusFromVotingPower based on the current voting power of the finality provider
 // updates the status, if it has some voting power, sets to active
 func (s *FinalityProviderStore) UpdateFpStatusFromVotingPower(


### PR DESCRIPTION
Closes #191. In particular, this PR:
- removed the loop for syncing fp status but syncing in the main thread during fp app initiation.
  - the loop is no longer needed as we have decided no fp will be registered via chain upgrade
  - we still need syncing status during initiation in case the fp is slashed or jailed
- in `monitorStatusUpdate`, the check for jailing and slashing is removed. This is because the removal of voting power due to slashing or jailing happens in the next block. Countering jailing and slashing in the loop will cause the fp to not vote when it still have voting power for the current block