### PR TITLE
fix: ChainType choices (to support consumer chains)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,58 +6,58 @@ on:
       - '**'
 
 jobs:
-  lint_test:
-    uses: babylonlabs-io/.github/.github/workflows/reusable_go_lint_test.yml@v0.7.0
-    secrets: inherit
-    with:
-      go-version: '1.23'
-      go-lint-version: 'v1.60.2'
-      run-unit-tests: true
-      run-lint: true
+  # lint_test:
+  #   uses: babylonlabs-io/.github/.github/workflows/reusable_go_lint_test.yml@v0.7.0
+  #   secrets: inherit
+  #   with:
+  #     go-version: '1.23'
+  #     go-lint-version: 'v1.60.2'
+  #     run-unit-tests: true
+  #     run-lint: true
 
-  e2e_babylon:
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up Go
-        uses: actions/setup-go@v4
-        with:
-          go-version: '1.23'
-      - name: Run e2e Babylon tests
-        run: make test-e2e-babylon
+  # e2e_babylon:
+  #   runs-on: ubuntu-22.04
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Set up Go
+  #       uses: actions/setup-go@v4
+  #       with:
+  #         go-version: '1.23'
+  #     - name: Run e2e Babylon tests
+  #       run: make test-e2e-babylon
 
-  e2e_wasmd:
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up Go
-        uses: actions/setup-go@v4
-        with:
-          go-version: '1.23'
-      - name: Run e2e Wasmd tests
-        run: make test-e2e-wasmd
+  # e2e_wasmd:
+  #   runs-on: ubuntu-22.04
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Set up Go
+  #       uses: actions/setup-go@v4
+  #       with:
+  #         go-version: '1.23'
+  #     - name: Run e2e Wasmd tests
+  #       run: make test-e2e-wasmd
 
-  e2e_bcd:
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up Go
-        uses: actions/setup-go@v4
-        with:
-          go-version: '1.23'
-      - name: Run e2e BCD tests
-        run: make test-e2e-bcd
+  # e2e_bcd:
+  #   runs-on: ubuntu-22.04
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Set up Go
+  #       uses: actions/setup-go@v4
+  #       with:
+  #         go-version: '1.23'
+  #     - name: Run e2e BCD tests
+  #       run: make test-e2e-bcd
 
-  e2e_op:
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up Go
-        uses: actions/setup-go@v4
-        with:
-          go-version: '1.23'
-      - name: Run e2e OP tests
-        run: make test-e2e-op
+  # e2e_op:
+  #   runs-on: ubuntu-22.04
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Set up Go
+  #       uses: actions/setup-go@v4
+  #       with:
+  #         go-version: '1.23'
+  #     - name: Run e2e OP tests
+  #       run: make test-e2e-op
 
   docker_pipeline:
     uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@v0.7.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,61 +6,61 @@ on:
       - '**'
 
 jobs:
-  # lint_test:
-  #   uses: babylonlabs-io/.github/.github/workflows/reusable_go_lint_test.yml@v0.7.0
-  #   secrets: inherit
-  #   with:
-  #     go-version: '1.23'
-  #     go-lint-version: 'v1.60.2'
-  #     run-unit-tests: true
-  #     run-lint: true
+  lint_test:
+    uses: babylonlabs-io/.github/.github/workflows/reusable_go_lint_test.yml@v0.7.0
+    secrets: inherit
+    with:
+      go-version: '1.23'
+      go-lint-version: 'v1.60.2'
+      run-unit-tests: true
+      run-lint: true
 
-  # e2e_babylon:
-  #   runs-on: ubuntu-22.04
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Set up Go
-  #       uses: actions/setup-go@v4
-  #       with:
-  #         go-version: '1.23'
-  #     - name: Run e2e Babylon tests
-  #       run: make test-e2e-babylon
+  e2e_babylon:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.23'
+      - name: Run e2e Babylon tests
+        run: make test-e2e-babylon
 
-  # e2e_wasmd:
-  #   runs-on: ubuntu-22.04
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Set up Go
-  #       uses: actions/setup-go@v4
-  #       with:
-  #         go-version: '1.23'
-  #     - name: Run e2e Wasmd tests
-  #       run: make test-e2e-wasmd
+  e2e_wasmd:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.23'
+      - name: Run e2e Wasmd tests
+        run: make test-e2e-wasmd
 
-  # e2e_bcd:
-  #   runs-on: ubuntu-22.04
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Set up Go
-  #       uses: actions/setup-go@v4
-  #       with:
-  #         go-version: '1.23'
-  #     - name: Run e2e BCD tests
-  #       run: make test-e2e-bcd
+  e2e_bcd:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.23'
+      - name: Run e2e BCD tests
+        run: make test-e2e-bcd
 
-  # e2e_op:
-  #   runs-on: ubuntu-22.04
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Set up Go
-  #       uses: actions/setup-go@v4
-  #       with:
-  #         go-version: '1.23'
-  #     - name: Run e2e OP tests
-  #       run: make test-e2e-op
+  e2e_op:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.23'
+      - name: Run e2e OP tests
+        run: make test-e2e-op
 
   docker_pipeline:
     uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@v0.7.0
     secrets: inherit
     with:
-      publish: true
+      publish: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,4 +63,4 @@ jobs:
     uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@v0.7.0
     secrets: inherit
     with:
-      publish: false
+      publish: true

--- a/finality-provider/config/config.go
+++ b/finality-provider/config/config.go
@@ -56,7 +56,7 @@ var (
 type Config struct {
 	LogLevel string `long:"loglevel" description:"Logging level for all subsystems" choice:"trace" choice:"debug" choice:"info" choice:"warn" choice:"error" choice:"fatal"`
 	// ChainType and ChainID (if any) of the chain config identify a consumer chain
-	ChainType                   string        `long:"chaintype" description:"the type of the consumer chain" choice:"babylon"`
+	ChainType                   string        `long:"chaintype" description:"the type of the consumer chain" choice:"babylon" choice:"OPStackL2" choice:"wasm"`
 	NumPubRand                  uint32        `long:"numPubRand" description:"The number of Schnorr public randomness for each commitment"`
 	NumPubRandMax               uint32        `long:"numpubrandmax" description:"The upper bound of the number of Schnorr public randomness for each commitment"`
 	MinRandHeightGap            uint32        `long:"minrandheightgap" description:"The minimum gap between the last committed rand height and the current Babylon block height"`


### PR DESCRIPTION
## Summary

fix a small bug which was introduced in https://github.com/babylonlabs-io/finality-provider/pull/155

this caused FP failed to start

```
bash-5.1$ fpd start
service injective.evm.v1beta1.Msg does not have cosmos.msg.v1.service proto annotation
Error: failed to load configuration: /home/finality-provider/.fpd/fpd.conf:6: Invalid value `OPStackL2' for option `--chaintype'. Allowed values are: 
Usage:
  fpd start [flags]
```

## Test Plan

tested with a new docker image created by CI
```
babylonlabs/finality-provider:9fcbde4fdacd26de256a944dedacb645826c2e9e
```

and it doesn't have this error anymore