### PR TITLE
chore: gradual benchmark pub rand

### DIFF
--- a/finality-provider/service/fp_instance.go
+++ b/finality-provider/service/fp_instance.go
@@ -1016,3 +1016,83 @@ func (fp *FinalityProviderInstance) GetFinalityProviderSlashedOrJailedWithRetry(
 
 	return slashed, jailed, nil
 }
+
+// CommitPubRandTiming - helper struct used to capture times for benchmark
+type CommitPubRandTiming struct {
+	GetPubRandListTime      time.Duration
+	AddPubRandProofListTime time.Duration
+	CommitPubRandListTime   time.Duration
+}
+
+// HelperCommitPubRand used for benchmark
+func (fp *FinalityProviderInstance) HelperCommitPubRand(tipHeight uint64) (*types.TxResponse, *CommitPubRandTiming, error) {
+	lastCommittedHeight, err := fp.GetLastCommittedHeight()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var startHeight uint64
+	switch {
+	case lastCommittedHeight == uint64(0):
+		// the finality-provider has never submitted public rand before
+		startHeight = tipHeight + 1
+	case lastCommittedHeight < uint64(fp.cfg.MinRandHeightGap)+tipHeight:
+		// (should not use subtraction because they are in the type of uint64)
+		// we are running out of the randomness
+		startHeight = lastCommittedHeight + 1
+	default:
+		fp.logger.Debug(
+			"the finality-provider has sufficient public randomness, skip committing more",
+			zap.String("pk", fp.GetBtcPkHex()),
+			zap.Uint64("block_height", tipHeight),
+			zap.Uint64("last_committed_height", lastCommittedHeight),
+		)
+		return nil, nil, nil
+	}
+
+	return fp.commitPubRandPairsWithTiming(startHeight)
+}
+
+func (fp *FinalityProviderInstance) commitPubRandPairsWithTiming(startHeight uint64) (*types.TxResponse, *CommitPubRandTiming, error) {
+	timing := &CommitPubRandTiming{}
+
+	activationBlkHeight, err := fp.cc.QueryFinalityActivationBlockHeight()
+	if err != nil {
+		return nil, timing, err
+	}
+
+	startHeight = max(startHeight, activationBlkHeight)
+
+	// Measure getPubRandList
+	pubRandListStart := time.Now()
+	pubRandList, err := fp.getPubRandList(startHeight, fp.cfg.NumPubRand)
+	if err != nil {
+		return nil, timing, fmt.Errorf("failed to generate randomness: %w", err)
+	}
+	timing.GetPubRandListTime = time.Since(pubRandListStart)
+
+	numPubRand := uint64(len(pubRandList))
+	commitment, proofList := types.GetPubRandCommitAndProofs(pubRandList)
+
+	// Measure addPubRandProofList
+	addProofStart := time.Now()
+	if err := fp.pubRandState.addPubRandProofList(pubRandList, proofList); err != nil {
+		return nil, timing, fmt.Errorf("failed to save public randomness to DB: %w", err)
+	}
+	timing.AddPubRandProofListTime = time.Since(addProofStart)
+
+	// Measure CommitPubRandList
+	commitListStart := time.Now()
+	schnorrSig, err := fp.signPubRandCommit(startHeight, numPubRand, commitment)
+	if err != nil {
+		return nil, timing, fmt.Errorf("failed to sign the Schnorr signature: %w", err)
+	}
+
+	res, err := fp.cc.CommitPubRandList(fp.GetBtcPk(), startHeight, numPubRand, commitment, schnorrSig)
+	if err != nil {
+		return nil, timing, fmt.Errorf("failed to commit public randomness to the consumer chain: %w", err)
+	}
+	timing.CommitPubRandListTime = time.Since(commitListStart)
+
+	return res, timing, nil
+}


### PR DESCRIPTION
I had to introduce helper functions to get gradual timing of functions inside `commitPubRandPairs`. 

### Findings 

Seems that most of the time is spent at `GetPubRandList` following `AddPubRandProofList`. As input (NumPubRand) grows we see an increase in time.


----
Results:

NumPubRand | Iterations (b.N) | Time per Iteration (ns/op) | Time per Iteration (ms) | AddPubRandProofList (ns / ms) | CommitPubRandList (ns / ms) | GetPubRandList (ns / ms)
-- | -- | -- | -- | -- | -- | --
10 | 42 | 27,770,395 | 27.77 | 14,544,106 / 14.54 | 1,442,187 / 1.44 | 11,753,113 / 11.75
50 | 16 | 68,078,846 | 68.08 | 15,242,174 / 15.24 | 1,242,602 / 1.24 | 51,516,203 / 51.52
100 | 9 | 122,120,093 | 122.12 | 16,093,750 / 16.09 | 1,271,602 / 1.27 | 104,604,153 / 104.60
200 | 5 | 231,700,700 | 231.70 | 17,093,217 / 17.09 | 1,268,492 / 1.27 | 213,090,417 / 213.09
500 | 2 | 546,630,958 | 546.63 | 20,933,896 / 20.93 | 1,244,730 / 1.24 | 523,769,854 / 523.77
1,000 | 1 | 1,063,210,125 | 1,063.21 | 20,605,666 / 20.61 | 1,276,208 / 1.28 | 1,039,780,500 / 1,039.78
5,000 | 1 | 5,235,733,292 | 5,235.73 | 37,567,250 / 37.57 | 1,250,916 / 1.25 | 5,193,632,875 / 5,193.63
10,000 | 1 | 10,479,790,875 | 10,479.79 | 73,979,584 / 73.98 | 1,314,334 / 1.31 | 10,397,781,458 / 10,397.78
25,000 | 1 | 26,012,446,417 | 26,012.45 | 245,269,750 / 245.27 | 1,380,083 / 1.38 | 25,750,781,708 / 25,750.78
50,000 | 1 | 52,544,326,750 | 52,544.33 | 816,153,875 / 816.15 | 1,354,375 / 1.35 | 51,695,706,875 / 51,695.71
75,000 | 1 | 79,272,072,959 | 79,272.07 | 1,696,296,750 / 1,696.30 | 1,275,250 / 1.28 | 77,517,351,000 / 77,517.35
100,000 | 1 | 106,582,957,334 | 106,582.96 | 2,905,885,458 / 2,905.89 | 1,341,375 / 1.34 | 103,598,760,375 / 103,598.76

----


[Closes](https://github.com/babylonlabs-io/finality-provider/issues/192)