### PR TITLE
fix: shouldn't wait `SubmissionRetryInterval` at the first iteration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,52 +15,52 @@ jobs:
       run-unit-tests: true
       run-lint: true
 
-  e2e_babylon:
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up Go
-        uses: actions/setup-go@v4
-        with:
-          go-version: '1.23'
-      - name: Run e2e Babylon tests
-        run: make test-e2e-babylon
+  # e2e_babylon:
+  #   runs-on: ubuntu-22.04
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Set up Go
+  #       uses: actions/setup-go@v4
+  #       with:
+  #         go-version: '1.23'
+  #     - name: Run e2e Babylon tests
+  #       run: make test-e2e-babylon
 
-  e2e_wasmd:
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up Go
-        uses: actions/setup-go@v4
-        with:
-          go-version: '1.23'
-      - name: Run e2e Wasmd tests
-        run: make test-e2e-wasmd
+  # e2e_wasmd:
+  #   runs-on: ubuntu-22.04
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Set up Go
+  #       uses: actions/setup-go@v4
+  #       with:
+  #         go-version: '1.23'
+  #     - name: Run e2e Wasmd tests
+  #       run: make test-e2e-wasmd
 
-  e2e_bcd:
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up Go
-        uses: actions/setup-go@v4
-        with:
-          go-version: '1.23'
-      - name: Run e2e BCD tests
-        run: make test-e2e-bcd
+  # e2e_bcd:
+  #   runs-on: ubuntu-22.04
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Set up Go
+  #       uses: actions/setup-go@v4
+  #       with:
+  #         go-version: '1.23'
+  #     - name: Run e2e BCD tests
+  #       run: make test-e2e-bcd
 
-  e2e_op:
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up Go
-        uses: actions/setup-go@v4
-        with:
-          go-version: '1.23'
-      - name: Run e2e OP tests
-        run: make test-e2e-op
+  # e2e_op:
+  #   runs-on: ubuntu-22.04
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Set up Go
+  #       uses: actions/setup-go@v4
+  #       with:
+  #         go-version: '1.23'
+  #     - name: Run e2e OP tests
+  #       run: make test-e2e-op
 
   docker_pipeline:
     uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@v0.7.0
     secrets: inherit
     with:
-      publish: false
+      publish: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,52 +15,52 @@ jobs:
       run-unit-tests: true
       run-lint: true
 
-  # e2e_babylon:
-  #   runs-on: ubuntu-22.04
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Set up Go
-  #       uses: actions/setup-go@v4
-  #       with:
-  #         go-version: '1.23'
-  #     - name: Run e2e Babylon tests
-  #       run: make test-e2e-babylon
+  e2e_babylon:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.23'
+      - name: Run e2e Babylon tests
+        run: make test-e2e-babylon
 
-  # e2e_wasmd:
-  #   runs-on: ubuntu-22.04
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Set up Go
-  #       uses: actions/setup-go@v4
-  #       with:
-  #         go-version: '1.23'
-  #     - name: Run e2e Wasmd tests
-  #       run: make test-e2e-wasmd
+  e2e_wasmd:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.23'
+      - name: Run e2e Wasmd tests
+        run: make test-e2e-wasmd
 
-  # e2e_bcd:
-  #   runs-on: ubuntu-22.04
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Set up Go
-  #       uses: actions/setup-go@v4
-  #       with:
-  #         go-version: '1.23'
-  #     - name: Run e2e BCD tests
-  #       run: make test-e2e-bcd
+  e2e_bcd:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.23'
+      - name: Run e2e BCD tests
+        run: make test-e2e-bcd
 
-  # e2e_op:
-  #   runs-on: ubuntu-22.04
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Set up Go
-  #       uses: actions/setup-go@v4
-  #       with:
-  #         go-version: '1.23'
-  #     - name: Run e2e OP tests
-  #       run: make test-e2e-op
+  e2e_op:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.23'
+      - name: Run e2e OP tests
+        run: make test-e2e-op
 
   docker_pipeline:
     uses: babylonlabs-io/.github/.github/workflows/reusable_docker_pipeline.yml@v0.7.0
     secrets: inherit
     with:
-      publish: true
+      publish: false

--- a/finality-provider/service/fp_instance.go
+++ b/finality-provider/service/fp_instance.go
@@ -403,58 +403,55 @@ func (fp *FinalityProviderInstance) retrySubmitSigsUntilFinalized(targetBlocks [
 	var failedCycles uint32
 	targetHeight := targetBlocks[len(targetBlocks)-1].Height
 
-	// we break the for loop if the block is finalized or the signature is successfully submitted
-	// error will be returned if maximum retries have been reached or the query to the consumer chain fails
+	// First iteration happens before the loop
 	for {
-		select {
-		case <-time.After(fp.cfg.SubmissionRetryInterval):
-			// error will be returned if max retries have been reached
-			var res *types.TxResponse
-			var err error
-			res, err = fp.SubmitBatchFinalitySignatures(targetBlocks)
-			if err != nil {
-				fp.logger.Debug(
-					"failed to submit finality signature to the consumer chain",
-					zap.String("pk", fp.GetBtcPkHex()),
-					zap.Uint32("current_failures", failedCycles),
-					zap.Uint64("target_start_height", targetBlocks[0].Height),
-					zap.Uint64("target_end_height", targetHeight),
-					zap.Error(err),
-				)
+		// Attempt submission immediately
+		res, err := fp.SubmitBatchFinalitySignatures(targetBlocks)
+		if err != nil {
+			fp.logger.Debug(
+				"failed to submit finality signature to the consumer chain",
+				zap.String("pk", fp.GetBtcPkHex()),
+				zap.Uint32("current_failures", failedCycles),
+				zap.Uint64("target_start_height", targetBlocks[0].Height),
+				zap.Uint64("target_end_height", targetHeight),
+				zap.Error(err),
+			)
 
-				if fpcc.IsUnrecoverable(err) {
-					return nil, err
-				}
-
-				if fpcc.IsExpected(err) {
-					return nil, nil
-				}
-
-				failedCycles++
-				if failedCycles > fp.cfg.MaxSubmissionRetries {
-					return nil, fmt.Errorf("reached max failed cycles with err: %w", err)
-				}
-			} else {
-				// the signature has been successfully submitted
-				return res, nil
+			if fpcc.IsUnrecoverable(err) {
+				return nil, err
 			}
 
-			// periodically query the index block to be later checked whether it is Finalized
-			finalized, err := fp.consumerCon.QueryIsBlockFinalized(targetHeight)
-			if err != nil {
-				return nil, fmt.Errorf("failed to query block finalization at height %v: %w", targetHeight, err)
-			}
-			if finalized {
-				fp.logger.Debug(
-					"the block is already finalized, skip submission",
-					zap.String("pk", fp.GetBtcPkHex()),
-					zap.Uint64("target_height", targetHeight),
-				)
-				// TODO: returning nil here is to safely break the loop
-				//  the error still exists
+			if fpcc.IsExpected(err) {
 				return nil, nil
 			}
 
+			failedCycles++
+			if failedCycles > fp.cfg.MaxSubmissionRetries {
+				return nil, fmt.Errorf("reached max failed cycles with err: %w", err)
+			}
+		} else {
+			// The signature has been successfully submitted
+			return res, nil
+		}
+
+		// Periodically query the index block to check whether it is finalized
+		finalized, err := fp.consumerCon.QueryIsBlockFinalized(targetHeight)
+		if err != nil {
+			return nil, fmt.Errorf("failed to query block finalization at height %v: %w", targetHeight, err)
+		}
+		if finalized {
+			fp.logger.Debug(
+				"the block is already finalized, skip submission",
+				zap.String("pk", fp.GetBtcPkHex()),
+				zap.Uint64("target_height", targetHeight),
+			)
+			return nil, nil
+		}
+
+		// Wait for the retry interval
+		select {
+		case <-time.After(fp.cfg.SubmissionRetryInterval):
+			// Continue to next retry iteration
 		case <-fp.quit:
 			fp.logger.Debug("the finality-provider instance is closing", zap.String("pk", fp.GetBtcPkHex()))
 			return nil, ErrFinalityProviderShutDown


### PR DESCRIPTION
## Summary

we found an issue in our OP devnet that finality sigs were submitted very slow. the root cause is we shouldn't wait 300 seconds in the first iteration in the for loop inside `retrySubmitSigsUntilFinalized()`

more context: https://github.com/babylonlabs-io/finality-provider/pull/155#discussion_r1881988164

## Test Plan

tested in our devnet with the new image

set `PollInterval` to 0.5 sec and see how it "fast synced" to the latest block

<img width="948" alt="image" src="https://github.com/user-attachments/assets/c1e2616f-6efb-4747-8cf9-c54fcb8a63c0" />
