### PR TITLE
docs: natively display status for created FP

### DIFF
--- a/docs/finality-provider-operation.md
+++ b/docs/finality-provider-operation.md
@@ -575,7 +575,7 @@ to:
 To check the status of a finality provider, you can use the following command:
 
 ```shell
-fpd finality-provider-info <eots-pk>
+fpd finality-provider-info <hex-string-of-eots-public-key>
 ```
 This will return the same response as the `create-finality-provider` 
 command but you will be able to check in real time the status of the 


### PR DESCRIPTION
closes: https://github.com/babylonlabs-io/finality-provider/issues/172

Previously In the docs we asked the operators to look at the bbn chain to verify the hash. I added this instruction so they can see their status, which is what we ultimately wanted them to check with the verification of the hash