### PR TITLE
feat: rm interceptors and use context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Improvements
 
 * [#251](https://github.com/babylonlabs-io/finality-provider/pull/251) chore: nlreturn lint
+* [#252](https://github.com/babylonlabs-io/finality-provider/pull/252) feat: rm interceptors and use context
 
 ## v0.14.2
 

--- a/eotsmanager/cmd/eotsd/daemon/start.go
+++ b/eotsmanager/cmd/eotsd/daemon/start.go
@@ -5,7 +5,6 @@ import (
 	"net"
 
 	sdkflags "github.com/cosmos/cosmos-sdk/client/flags"
-	"github.com/lightningnetwork/lnd/signal"
 	"github.com/spf13/cobra"
 
 	"github.com/babylonlabs-io/finality-provider/eotsmanager"
@@ -66,13 +65,7 @@ func startFn(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("failed to create EOTS manager: %w", err)
 	}
 
-	// Hook interceptor for os signals.
-	shutdownInterceptor, err := signal.Intercept()
-	if err != nil {
-		return fmt.Errorf("failed to set up shutdown interceptor: %w", err)
-	}
+	eotsServer := eotsservice.NewEOTSManagerServer(cfg, logger, eotsManager, dbBackend)
 
-	eotsServer := eotsservice.NewEOTSManagerServer(cfg, logger, eotsManager, dbBackend, shutdownInterceptor)
-
-	return eotsServer.RunUntilShutdown()
+	return eotsServer.RunUntilShutdown(cmd.Context())
 }

--- a/eotsmanager/cmd/eotsd/main.go
+++ b/eotsmanager/cmd/eotsd/main.go
@@ -16,6 +16,6 @@ func main() {
 
 	if err := daemon.NewRootCmd().ExecuteContext(ctx); err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "Error while executing eotsd CLI: %s", err.Error())
-		os.Exit(1)
+		os.Exit(1) //nolint:gocritic
 	}
 }

--- a/eotsmanager/cmd/eotsd/main.go
+++ b/eotsmanager/cmd/eotsd/main.go
@@ -1,15 +1,21 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/babylonlabs-io/finality-provider/eotsmanager/cmd/eotsd/daemon"
 )
 
 func main() {
-	if err := daemon.NewRootCmd().Execute(); err != nil {
-		fmt.Fprintf(os.Stderr, "Error while executing eotsd CLI: %s", err.Error())
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+
+	if err := daemon.NewRootCmd().ExecuteContext(ctx); err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "Error while executing eotsd CLI: %s", err.Error())
 		os.Exit(1)
 	}
 }

--- a/eotsmanager/service/server.go
+++ b/eotsmanager/service/server.go
@@ -68,7 +68,7 @@ func (s *Server) RunUntilShutdown(ctx context.Context) error {
 		} else {
 			s.logger.Info("Database closed")
 		}
-		metricsServer.Stop(context.Background())
+		metricsServer.Stop(ctx)
 		s.logger.Info("Metrics server stopped")
 	}()
 

--- a/eotsmanager/service/server.go
+++ b/eotsmanager/service/server.go
@@ -98,7 +98,6 @@ func (s *Server) RunUntilShutdown(ctx context.Context) error {
 
 	// Wait for shutdown signal from either a graceful server stop or from
 	// the interrupt handler.
-	// <-s.interceptor.ShutdownChannel()
 	<-ctx.Done()
 
 	return nil

--- a/finality-provider/cmd/fpd/daemon/start.go
+++ b/finality-provider/cmd/fpd/daemon/start.go
@@ -8,7 +8,6 @@ import (
 	"github.com/babylonlabs-io/babylon/types"
 	"github.com/btcsuite/btcwallet/walletdb"
 	"github.com/cosmos/cosmos-sdk/client"
-	"github.com/lightningnetwork/lnd/signal"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
 
@@ -91,15 +90,9 @@ func runStartCmd(ctx client.Context, cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("failed to start app: %w", err)
 	}
 
-	// Hook interceptor for os signals.
-	shutdownInterceptor, err := signal.Intercept()
-	if err != nil {
-		return err
-	}
+	fpServer := service.NewFinalityProviderServer(cfg, logger, fpApp, dbBackend)
 
-	fpServer := service.NewFinalityProviderServer(cfg, logger, fpApp, dbBackend, shutdownInterceptor)
-
-	return fpServer.RunUntilShutdown()
+	return fpServer.RunUntilShutdown(cmd.Context())
 }
 
 // loadApp initialize an finality provider app based on config and flags set.

--- a/finality-provider/cmd/fpd/main.go
+++ b/finality-provider/cmd/fpd/main.go
@@ -48,6 +48,6 @@ func main() {
 
 	if err := cmd.ExecuteContext(ctx); err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "Whoops. There was an error while executing your fpd CLI '%s'", err)
-		os.Exit(1)
+		os.Exit(1) //nolint:gocritic
 	}
 }

--- a/finality-provider/cmd/fpd/main.go
+++ b/finality-provider/cmd/fpd/main.go
@@ -1,8 +1,11 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
+	"os/signal"
+	"syscall"
 
 	incentivecli "github.com/babylonlabs-io/babylon/x/incentive/client/cli"
 	"github.com/cosmos/cosmos-sdk/client"
@@ -40,8 +43,11 @@ func main() {
 		version.CommandVersion("fpd"), daemon.CommandUnsafePruneMerkleProof(),
 	)
 
-	if err := cmd.Execute(); err != nil {
-		fmt.Fprintf(os.Stderr, "Whoops. There was an error while executing your fpd CLI '%s'", err)
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+
+	if err := cmd.ExecuteContext(ctx); err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "Whoops. There was an error while executing your fpd CLI '%s'", err)
 		os.Exit(1)
 	}
 }

--- a/finality-provider/service/server.go
+++ b/finality-provider/service/server.go
@@ -96,7 +96,6 @@ func (s *Server) RunUntilShutdown(ctx context.Context) error {
 
 	// Wait for shutdown signal from either a graceful server stop or from
 	// the interrupt handler.
-	// <-s.interceptor.ShutdownChannel()
 	<-ctx.Done()
 
 	return nil

--- a/finality-provider/service/server.go
+++ b/finality-provider/service/server.go
@@ -66,7 +66,7 @@ func (s *Server) RunUntilShutdown(ctx context.Context) error {
 		} else {
 			s.logger.Info("Database closed")
 		}
-		metricsServer.Stop(context.Background())
+		metricsServer.Stop(ctx)
 		s.logger.Info("Metrics server stopped")
 	}()
 

--- a/itest/e2e_test.go
+++ b/itest/e2e_test.go
@@ -43,6 +43,7 @@ var (
 // The test runs 2 finality providers connecting to
 // a single EOTS manager
 func TestFinalityProviderLifeCycle(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	n := 2
@@ -82,6 +83,7 @@ func TestFinalityProviderLifeCycle(t *testing.T) {
 // sends a finality vote over a conflicting block
 // in this case, the BTC private key should be extracted by Babylon
 func TestDoubleSigning(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	tm, fps := StartManagerWithFinalityProvider(t, 1, ctx)
@@ -144,6 +146,7 @@ func TestDoubleSigning(t *testing.T) {
 
 // TestCatchingUp tests if a fp can catch up after restarted
 func TestCatchingUp(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	tm, fps := StartManagerWithFinalityProvider(t, 1, ctx)
@@ -195,6 +198,7 @@ func TestCatchingUp(t *testing.T) {
 }
 
 func TestFinalityProviderEditCmd(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	tm, fps := StartManagerWithFinalityProvider(t, 1, ctx)
@@ -279,6 +283,7 @@ func TestFinalityProviderEditCmd(t *testing.T) {
 }
 
 func TestFinalityProviderCreateCmd(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	tm, fps := StartManagerWithFinalityProvider(t, 1, ctx)
@@ -345,6 +350,7 @@ func TestFinalityProviderCreateCmd(t *testing.T) {
 }
 
 func TestRemoveMerkleProofsCmd(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	tm, fps := StartManagerWithFinalityProvider(t, 1, ctx)
@@ -374,6 +380,7 @@ func TestRemoveMerkleProofsCmd(t *testing.T) {
 }
 
 func TestPrintEotsCmd(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	tm := StartManager(t, ctx)

--- a/itest/e2e_test.go
+++ b/itest/e2e_test.go
@@ -5,6 +5,7 @@ package e2etest
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -42,8 +43,10 @@ var (
 // The test runs 2 finality providers connecting to
 // a single EOTS manager
 func TestFinalityProviderLifeCycle(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	n := 2
-	tm, fps := StartManagerWithFinalityProvider(t, n)
+	tm, fps := StartManagerWithFinalityProvider(t, n, ctx)
 	defer tm.Stop(t)
 
 	// check the public randomness is committed
@@ -79,7 +82,9 @@ func TestFinalityProviderLifeCycle(t *testing.T) {
 // sends a finality vote over a conflicting block
 // in this case, the BTC private key should be extracted by Babylon
 func TestDoubleSigning(t *testing.T) {
-	tm, fps := StartManagerWithFinalityProvider(t, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	tm, fps := StartManagerWithFinalityProvider(t, 1, ctx)
 	defer tm.Stop(t)
 
 	fpIns := fps[0]
@@ -139,7 +144,9 @@ func TestDoubleSigning(t *testing.T) {
 
 // TestCatchingUp tests if a fp can catch up after restarted
 func TestCatchingUp(t *testing.T) {
-	tm, fps := StartManagerWithFinalityProvider(t, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	tm, fps := StartManagerWithFinalityProvider(t, 1, ctx)
 	defer tm.Stop(t)
 
 	fpIns := fps[0]
@@ -188,7 +195,9 @@ func TestCatchingUp(t *testing.T) {
 }
 
 func TestFinalityProviderEditCmd(t *testing.T) {
-	tm, fps := StartManagerWithFinalityProvider(t, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	tm, fps := StartManagerWithFinalityProvider(t, 1, ctx)
 	defer tm.Stop(t)
 
 	fpIns := fps[0]
@@ -270,7 +279,9 @@ func TestFinalityProviderEditCmd(t *testing.T) {
 }
 
 func TestFinalityProviderCreateCmd(t *testing.T) {
-	tm, fps := StartManagerWithFinalityProvider(t, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	tm, fps := StartManagerWithFinalityProvider(t, 1, ctx)
 	defer tm.Stop(t)
 
 	fpIns := fps[0]
@@ -334,7 +345,9 @@ func TestFinalityProviderCreateCmd(t *testing.T) {
 }
 
 func TestRemoveMerkleProofsCmd(t *testing.T) {
-	tm, fps := StartManagerWithFinalityProvider(t, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	tm, fps := StartManagerWithFinalityProvider(t, 1, ctx)
 	defer tm.Stop(t)
 
 	fpIns := fps[0]
@@ -361,7 +374,9 @@ func TestRemoveMerkleProofsCmd(t *testing.T) {
 }
 
 func TestPrintEotsCmd(t *testing.T) {
-	tm := StartManager(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	tm := StartManager(t, ctx)
 	r := rand.New(rand.NewSource(time.Now().Unix()))
 	defer tm.Stop(t)
 
@@ -375,7 +390,7 @@ func TestPrintEotsCmd(t *testing.T) {
 		expected[eotsKeyName] = bbntypes.NewBIP340PubKeyFromBTCPK(pk).MarshalHex()
 	}
 
-	tm.EOTSServerHandler.Stop()
+	cancel()
 
 	cmd := eotscmd.CommandPrintAllKeys()
 

--- a/itest/test_manager.go
+++ b/itest/test_manager.go
@@ -127,6 +127,7 @@ func StartManager(t *testing.T, ctx context.Context) *TestManager {
 	eotsHomeDir := filepath.Join(testDir, "eots-home")
 	eotsCfg := eotsconfig.DefaultConfigWithHomePath(eotsHomeDir)
 	eotsCfg.RPCListener = fmt.Sprintf("127.0.0.1:%d", testutil.AllocateUniquePort(t))
+	eotsCfg.Metrics.Port = testutil.AllocateUniquePort(t)
 	eh := NewEOTSServerHandler(t, eotsCfg, eotsHomeDir)
 	eh.Start(ctx)
 	cfg.RPCListener = fmt.Sprintf("127.0.0.1:%d", testutil.AllocateUniquePort(t))
@@ -170,7 +171,7 @@ func (tm *TestManager) AddFinalityProvider(t *testing.T, ctx context.Context) *s
 	cfg.BabylonConfig.GRPCAddr = fmt.Sprintf("https://localhost:%s", tm.babylond.GetPort("9090/tcp"))
 	fpBbnKeyInfo, err := testutil.CreateChainKey(cfg.BabylonConfig.KeyDirectory, cfg.BabylonConfig.ChainID, cfg.BabylonConfig.Key, cfg.BabylonConfig.KeyringBackend, passphrase, hdPath, "")
 	require.NoError(t, err)
-
+	
 	// add some funds for new fp pay for fees '-'
 	_, _, err = tm.manager.BabylondTxBankSend(t, fpBbnKeyInfo.AccAddress.String(), "1000000ubbn", "node0")
 	require.NoError(t, err)

--- a/testutil/port.go
+++ b/testutil/port.go
@@ -24,11 +24,11 @@ func AllocateUniquePort(t *testing.T) int {
 	// Base port and spread range for port selection
 	const (
 		basePort  = 20000
-		portRange = 30000
+		portRange = 40000
 	)
 
-	// Try up to 10 times to find an available port
-	for i := 0; i < 10; i++ {
+	// Try up to 20 times to find an available port
+	for i := 0; i < 20; i++ {
 		port := randPort(basePort, portRange)
 
 		// Lock the mutex to check and modify the shared map


### PR DESCRIPTION
This PR removes the usage of `signal.Interceptor` and uses Go's idiomatic `context` to handle cancellations. This enables us to run e2e tests in parallel (almost 4x faster).

```
//old-time
ok      github.com/babylonlabs-io/finality-provider/itest       548.976s
// new time
ok      github.com/babylonlabs-io/finality-provider/itest       139.579s
```

Time in GH action `9m 58s` vs `3m 24s`


Closes #219 