### PR TITLE
[backport] chore: Improve fpd start (#294)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## Unreleased
 
+### Improvements
+
+* [#294](https://github.com/babylonlabs-io/finality-provider/pull/294) chore: Improve fpd start
+
 ## v0.14.3
 
 ### Improvements

--- a/docs/finality-provider-operation.md
+++ b/docs/finality-provider-operation.md
@@ -549,7 +549,8 @@ your finality provider's details:
       "status": "REGISTERED"
     }
     "tx_hash": "C08377CF289DF0DC5FA462E6409ADCB65A3492C22A112C58EA449F4DC544A3B1"
-} 
+}
+Your finality provider is successfully created. Please restart your fpd. 
 ```
 
 The response includes: 
@@ -584,6 +585,10 @@ by running:
 ```shell
 fpd start --eots-pk <hex-string-of-eots-public-key>
 ```
+
+If `--eots-pk` is not specified, the command will start the finality provider
+if it is the only one stored in the database. If multiple finality providers
+are in the database, specifying `--eots-pk` is required.
 
 ### 5.2. Withdrawing Rewards
 

--- a/finality-provider/cmd/cmd_test.go
+++ b/finality-provider/cmd/cmd_test.go
@@ -6,16 +6,16 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/babylonlabs-io/babylon/testutil/datagen"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
+	goflags "github.com/jessevdk/go-flags"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 
-	"github.com/babylonlabs-io/babylon/testutil/datagen"
 	fpcmd "github.com/babylonlabs-io/finality-provider/finality-provider/cmd"
 	fpcfg "github.com/babylonlabs-io/finality-provider/finality-provider/config"
 	"github.com/babylonlabs-io/finality-provider/util"
-	goflags "github.com/jessevdk/go-flags"
 )
 
 func TestPersistClientCtx(t *testing.T) {

--- a/finality-provider/cmd/fpd/daemon/daemon_commands.go
+++ b/finality-provider/cmd/fpd/daemon/daemon_commands.go
@@ -195,6 +195,9 @@ func runCommandCreateFP(ctx client.Context, cmd *cobra.Command, _ []string) erro
 	}
 
 	printRespJSON(res)
+
+	cmd.Println("Your finality provider is successfully created. Please restart your fpd.")
+
 	return nil
 }
 

--- a/finality-provider/service/app.go
+++ b/finality-provider/service/app.go
@@ -175,6 +175,10 @@ func (app *FinalityProviderApp) GetFinalityProviderInstance() (*FinalityProvider
 	return app.fpIns, nil
 }
 
+func (app *FinalityProviderApp) Logger() *zap.Logger {
+	return app.logger
+}
+
 // StartFinalityProvider starts a finality provider instance with the given EOTS public key
 // Note: this should be called right after the finality-provider is registered
 func (app *FinalityProviderApp) StartFinalityProvider(fpPk *bbntypes.BIP340PubKey, passphrase string) error {
@@ -411,14 +415,6 @@ func (app *FinalityProviderApp) CreateFinalityProvider(
 		storedFp, err := app.fps.GetFinalityProvider(btcPk)
 		if err != nil {
 			return nil, err
-		}
-
-		if err = app.startFinalityProviderInstance(storedFp.GetBIP340BTCPK(), ""); err != nil {
-			app.logger.Error(
-				"failed to start fp instance",
-				zap.String("eots_pk", pkHex),
-				zap.Error(err),
-			)
 		}
 
 		return &CreateFinalityProviderResult{

--- a/itest/test_manager.go
+++ b/itest/test_manager.go
@@ -122,7 +122,7 @@ func StartManager(t *testing.T) *TestManager {
 	require.Eventually(t, func() bool {
 		bc, err = fpcc.NewBabylonController(cfg.BabylonConfig, &cfg.BTCNetParams, logger)
 		return err == nil
-	}, 5*time.Second, eventuallyPollTime)
+	}, 10*time.Second, eventuallyPollTime)
 
 	shutdownInterceptor, err := signal.Intercept()
 	require.NoError(t, err)
@@ -200,6 +200,9 @@ func (tm *TestManager) AddFinalityProvider(t *testing.T) *service.FinalityProvid
 
 	cfg.RPCListener = fmt.Sprintf("127.0.0.1:%d", testutil.AllocateUniquePort(t))
 	cfg.Metrics.Port = testutil.AllocateUniquePort(t)
+
+	err = fpApp.StartFinalityProvider(eotsPk, passphrase)
+	require.NoError(t, err)
 
 	fpServer := service.NewFinalityProviderServer(cfg, tm.logger, fpApp, fpdb, tm.interceptor)
 	go func() {


### PR DESCRIPTION
Closes #289. With this pr, the `fpd start` flow becomes the follows:

- If --eots-pk is specified, start the specified fp instance. Otherwise,
- if no fp records found from db, start the daemon and show logs asking for registration
- if there's one fp record found from db, start the daemon with the fp
- if there are multiple fp record found from db, fail the cmd execution asking for set of --eots-pk