### PR TITLE
fix: no add failed cycles count when chain poller no found new blocks

### DIFF
--- a/finality-provider/service/chain_poller.go
+++ b/finality-provider/service/chain_poller.go
@@ -112,8 +112,14 @@ func (cp *ChainPoller) blocksWithRetry(start, end uint64, limit uint32) ([]*type
 			return err
 		}
 
+		// no need return error when just no found new blocks,
+		// the chain to poller may not produce new blocks.
 		if len(block) == 0 {
-			return fmt.Errorf("no blocks found for range %d-%d", start, end)
+			cp.logger.Warn(
+				"no blocks found for range",
+				zap.Uint64("start_height", start),
+				zap.Uint64("end_height", end),
+			)
 		}
 
 		return nil

--- a/finality-provider/service/chain_poller.go
+++ b/finality-provider/service/chain_poller.go
@@ -207,16 +207,9 @@ func (cp *ChainPoller) pollChain() {
 		} else {
 			// start polling in the first iteration
 			blockToRetrieve := cp.NextHeight()
-			var blocks []*types.BlockInfo
-			var err error
-			if blockToRetrieve == latestBlockHeight {
-				var latestBlock *types.BlockInfo
-				latestBlock, err = cp.consumerCon.QueryBlock(latestBlockHeight)
-				blocks = []*types.BlockInfo{latestBlock}
-			} else {
-				blocks, err = cp.blocksWithRetry(blockToRetrieve, latestBlockHeight, cp.cfg.PollSize)
-			}
+			err := cp.tryPollChain(latestBlockHeight, blockToRetrieve)
 
+			// update the failed cycles
 			if err != nil {
 				failedCycles++
 				cp.logger.Debug(
@@ -229,26 +222,15 @@ func (cp *ChainPoller) pollChain() {
 			} else {
 				// no error and we got the header we wanted to get, bump the state and push
 				// notification about data
+				if failedCycles > 0 {
+					cp.logger.Debug(
+						"query the consumer chain for the block range success from an error",
+						zap.Uint32("current_failures", failedCycles),
+						zap.Uint64("start_height", blockToRetrieve),
+						zap.Uint64("end_height", latestBlockHeight),
+					)
+				}
 				failedCycles = 0
-				if len(blocks) == 0 {
-					continue
-				}
-
-				lb := blocks[len(blocks)-1]
-				cp.setNextHeight(lb.Height + 1)
-
-				cp.metrics.RecordLastPolledHeight(lb.Height)
-
-				cp.logger.Info("the poller retrieved the blocks from the consumer chain",
-					zap.Uint64("start_height", blockToRetrieve),
-					zap.Uint64("end_height", lb.Height))
-
-				// push the data to the channel
-				// Note: if the consumer is too slow -- the buffer is full
-				// the channel will block, and we will stop retrieving data from the node
-				for _, block := range blocks {
-					cp.blockInfoChan <- block
-				}
 			}
 		}
 
@@ -262,6 +244,49 @@ func (cp *ChainPoller) pollChain() {
 			return
 		}
 	}
+}
+
+func (cp *ChainPoller) tryPollChain(latestBlockHeight, blockToRetrieve uint64) error {
+	var blocks []*types.BlockInfo
+	var err error
+	if blockToRetrieve == latestBlockHeight {
+		var latestBlock *types.BlockInfo
+		latestBlock, err = cp.consumerCon.QueryBlock(latestBlockHeight)
+		blocks = []*types.BlockInfo{latestBlock}
+	} else {
+		blocks, err = cp.blocksWithRetry(blockToRetrieve, latestBlockHeight, cp.cfg.PollSize)
+	}
+
+	// find error need return
+	if err != nil {
+		return err
+	}
+
+	// no error and we got the header we wanted to get, bump the state and push
+	// notification about data
+	if len(blocks) == 0 {
+		// NOTE: when no found blocks, we need to wait PollInterval to
+		// await too much requests.
+		return nil
+	}
+
+	lb := blocks[len(blocks)-1]
+	cp.setNextHeight(lb.Height + 1)
+
+	cp.metrics.RecordLastPolledHeight(lb.Height)
+
+	cp.logger.Info("the poller retrieved the blocks from the consumer chain",
+		zap.Uint64("start_height", blockToRetrieve),
+		zap.Uint64("end_height", lb.Height))
+
+	// push the data to the channel
+	// Note: if the consumer is too slow -- the buffer is full
+	// the channel will block, and we will stop retrieving data from the node
+	for _, block := range blocks {
+		cp.blockInfoChan <- block
+	}
+
+	return nil
 }
 
 func (cp *ChainPoller) NextHeight() uint64 {


### PR DESCRIPTION
When chain poller try to got new blocks, it will count a `failedCycles`, when it > `maxFailedCycles`, the finality-provider will exit by:

```go
		if failedCycles > maxFailedCycles {
			cp.logger.Fatal("the poller has reached the max failed cycles, exiting")
		}
```

BUT in chain poller, when the poller no got new blocks during `PollInterval`, it will also add `failedCycles`.

So when the chain no produce blocks in `PollInterval` * `maxFailedCycles`, the fp will exit.

For some chain, it may no produce blocks when no new tx, and in some times, the chain will pause by chain upgrade, so it will make the fp exit by the error.

So in this PR, we make `failedCycles ` no update when no new blocks.