### PR TITLE
poller: skip if no new block is polled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## Unreleased
 
+### Improvements
+
 * [#331](https://github.com/babylonlabs-io/finality-provider/pull/331) Bump Cosmos integration dependencies
+
+### Bug Fixes
+
+* [#333](https://github.com/babylonlabs-io/finality-provider/pull/333) poller: skip if no new block is polled
 * [#328](https://github.com/babylonlabs-io/finality-provider/pull/328) Fix small bias in EOTS private key generation
 
 ## v1.0.0-rc.1

--- a/finality-provider/service/chain_poller.go
+++ b/finality-provider/service/chain_poller.go
@@ -255,11 +255,19 @@ func (cp *ChainPoller) pollChain() {
 func (cp *ChainPoller) tryPollChain(latestBlockHeight, blockToRetrieve uint64) error {
 	var blocks []*types.BlockInfo
 	var err error
-	if blockToRetrieve == latestBlockHeight {
+
+	switch {
+	case blockToRetrieve > latestBlockHeight:
+		cp.logger.Debug(
+			"skipping block query as there is no new block",
+			zap.Uint64("next_height", blockToRetrieve),
+			zap.Uint64("latest_height", latestBlockHeight),
+		)
+	case blockToRetrieve == latestBlockHeight:
 		var latestBlock *types.BlockInfo
 		latestBlock, err = cp.consumerCon.QueryBlock(latestBlockHeight)
 		blocks = []*types.BlockInfo{latestBlock}
-	} else {
+	default:
 		blocks, err = cp.blocksWithRetry(blockToRetrieve, latestBlockHeight, cp.cfg.PollSize)
 	}
 

--- a/finality-provider/service/chain_poller.go
+++ b/finality-provider/service/chain_poller.go
@@ -115,7 +115,7 @@ func (cp *ChainPoller) blocksWithRetry(start, end uint64, limit uint32) ([]*type
 		// no need return error when just no found new blocks,
 		// the chain to poller may not produce new blocks.
 		if len(block) == 0 {
-			cp.logger.Warn(
+			cp.logger.Debug(
 				"no blocks found for range",
 				zap.Uint64("start_height", start),
 				zap.Uint64("end_height", end),


### PR DESCRIPTION
Part of https://github.com/babylonlabs-io/babylon-integration-deployment/pull/32

`latestBlockHeight` can be the current height if there is no new block during this polling iteration, but `blockToRetrieve` is set `cp.NextHeight()` , meaning that `blockToRetrieve` can be bigger than `latestBlockHeight` by `1`.

This PR adds a check on `blockToRetrieve > lastestBlockHeight`, and skips with some logging if this occurs