### PR TITLE
chore: fix CosmWasm controller 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## Unreleased
 
+### Improvements
+
+* [#335](https://github.com/babylonlabs-io/finality-provider/pull/335) chore: fix CosmWasm controller
 * [#331](https://github.com/babylonlabs-io/finality-provider/pull/331) Bump Cosmos integration dependencies
+
+### Bug Fixes
+
 * [#328](https://github.com/babylonlabs-io/finality-provider/pull/328) Fix small bias in EOTS private key generation
 
 ## v1.0.0-rc.1

--- a/clientcontroller/cosmwasm/consumer.go
+++ b/clientcontroller/cosmwasm/consumer.go
@@ -519,6 +519,10 @@ func (wc *CosmwasmConsumerController) queryCometBestBlock() (*fptypes.BlockInfo,
 }
 
 func (wc *CosmwasmConsumerController) queryCometBlocksInRange(startHeight, endHeight uint64) ([]*fptypes.BlockInfo, error) {
+	if startHeight > endHeight {
+		return nil, fmt.Errorf("the startHeight %v should not be higher than the endHeight %v", startHeight, endHeight)
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), wc.cfg.Timeout)
 	defer cancel()
 

--- a/clientcontroller/cosmwasm/consumer.go
+++ b/clientcontroller/cosmwasm/consumer.go
@@ -192,7 +192,7 @@ func (wc *CosmwasmConsumerController) SubmitBatchFinalitySigs(
 
 		execMsg := &wasmdtypes.MsgExecuteContract{
 			Sender:   wc.cwClient.MustGetAddr(),
-			Contract: sdk.MustAccAddressFromBech32(wc.cfg.BtcFinalityContractAddress).String(),
+			Contract: wc.cfg.BtcFinalityContractAddress,
 			Msg:      msgBytes,
 		}
 		msgs = append(msgs, execMsg)


### PR DESCRIPTION
Part of https://github.com/babylonlabs-io/babylon-integration-deployment/pull/32

- ensure `startHeight <= endHeight` for range queries
- avoid unnecessary conversions between `sdk.AccAddress` and string address