### PR TITLE
[Backport] poller: skip if no new block is polled (#333)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Bug Fixes
 
+* [#333](https://github.com/babylonlabs-io/finality-provider/pull/333) poller: skip if no new block is polled
 * [#328](https://github.com/babylonlabs-io/finality-provider/pull/328) Fix small bias in EOTS private key generation
 * [#327](https://github.com/babylonlabs-io/finality-provider/pull/327) fix: no add failed cycles count when chain poller no found new blocks
 


### PR DESCRIPTION
Part of
https://github.com/babylonlabs-io/babylon-integration-deployment/pull/32

`latestBlockHeight` can be the current height if there is no new block during this polling iteration, but `blockToRetrieve` is set `cp.NextHeight()` , meaning that `blockToRetrieve` can be bigger than `latestBlockHeight` by `1`.

This PR adds a check on `blockToRetrieve > lastestBlockHeight`, and skips with some logging if this occurs