### PR TITLE
feat: Add recover proof cmd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 * [#335](https://github.com/babylonlabs-io/finality-provider/pull/335) chore: fix CosmWasm controller
 * [#331](https://github.com/babylonlabs-io/finality-provider/pull/331) Bump Cosmos integration dependencies
+* [#351](https://github.com/babylonlabs-io/finality-provider/pull/351) Add recover proof cmd
 
 ### Bug Fixes
 

--- a/clientcontroller/babylon/consumer.go
+++ b/clientcontroller/babylon/consumer.go
@@ -500,20 +500,16 @@ func (bc *BabylonConsumerController) QueryPublicRandCommitList(fpPk *btcec.Publi
 		if err := commit.Validate(); err != nil {
 			return nil, err
 		}
-		pagination.Key = res.Pagination.NextKey
 
-		commitStartHeight := commit.StartHeight
-		commitEndHeight := commit.EndHeight()
-
-		if startHeight > commitEndHeight {
-			continue
+		if startHeight <= commit.EndHeight() {
+			commitList = append(commitList, commit)
 		}
 
-		commitList = append(commitList, commit)
-
-		if startHeight >= commitStartHeight {
+		if res.Pagination == nil || res.Pagination.NextKey == nil {
 			break
 		}
+
+		pagination.Key = res.Pagination.NextKey
 	}
 
 	return commitList, nil

--- a/clientcontroller/babylon/consumer.go
+++ b/clientcontroller/babylon/consumer.go
@@ -463,3 +463,58 @@ func (bc *BabylonConsumerController) UnjailFinalityProvider(fpPk *btcec.PublicKe
 
 	return &types.TxResponse{TxHash: res.TxHash, Events: res.Events}, nil
 }
+
+// QueryPublicRandCommitList returns the public randomness commitments list from the startHeight to the last commit
+// the returned commits are ordered in the accenting order of the start height
+func (bc *BabylonConsumerController) QueryPublicRandCommitList(fpPk *btcec.PublicKey, startHeight uint64) ([]*types.PubRandCommit, error) {
+	fpBtcPk := bbntypes.NewBIP340PubKeyFromBTCPK(fpPk)
+
+	pagination := &sdkquery.PageRequest{
+		Limit:   1,
+		Reverse: false,
+	}
+
+	commitList := make([]*types.PubRandCommit, 0)
+
+	for {
+		res, err := bc.bbnClient.QueryClient.ListPubRandCommit(fpBtcPk.MarshalHex(), pagination)
+		if err != nil {
+			return nil, fmt.Errorf("failed to query committed public randomness: %w", err)
+		}
+
+		if len(res.PubRandCommitMap) == 0 {
+			// expected when there is no PR commit at all
+			return nil, nil
+		}
+		if len(res.PubRandCommitMap) > 1 {
+			return nil, fmt.Errorf("expected length to be 1, but get :%d", len(res.PubRandCommitMap))
+		}
+		var commit *types.PubRandCommit
+		for height, commitRes := range res.PubRandCommitMap {
+			commit = &types.PubRandCommit{
+				StartHeight: height,
+				NumPubRand:  commitRes.NumPubRand,
+				Commitment:  commitRes.Commitment,
+			}
+		}
+		if err := commit.Validate(); err != nil {
+			return nil, err
+		}
+		pagination.Key = res.Pagination.NextKey
+
+		commitStartHeight := commit.StartHeight
+		commitEndHeight := commit.EndHeight()
+
+		if startHeight > commitEndHeight {
+			continue
+		}
+
+		commitList = append(commitList, commit)
+
+		if startHeight >= commitStartHeight {
+			break
+		}
+	}
+
+	return commitList, nil
+}

--- a/docs/finality-provider-operation.md
+++ b/docs/finality-provider-operation.md
@@ -943,11 +943,11 @@ For Finality Provider:
 
 > 🔒 **Security Note**: While database files can be recreated, loss of private keys in the keyring directories is **irrecoverable** and will result in permanent loss of your finality provider position and accumulated rewards.
 
-### 7.3 Recover fpd.db
+### 7.3 Recover finality-provider.db
 
-The `fpd.db` file contains both the finality provider's running status and the
-public randomness merkle proof. Either information is compromised will lead
-to service halt, but they are recoverable.
+The `finality-provider.db` file contains both the finality provider's running
+status and the public randomness merkle proof. Either information loss
+compromised will lead to service halt, but they are recoverable.
 
 #### 7.3.1 Recover local status of a finality provider
 

--- a/docs/finality-provider-operation.md
+++ b/docs/finality-provider-operation.md
@@ -983,3 +983,5 @@ which you want to recover from as some proof for old height do not need to be
 recovered. The command will recover the proof from the `start-height` to
 the latest committed height on Babylon. If `start-height` is not specified,
 it will recover all the proof until the latest committed height on Babylon.
+Note that `fpd` needs to be stopped before recovering the proof as otherwise,
+the database file might be locked.

--- a/finality-provider/cmd/fpd/daemon/recover_proof.go
+++ b/finality-provider/cmd/fpd/daemon/recover_proof.go
@@ -98,6 +98,11 @@ func runCommandRecoverProof(ctx client.Context, cmd *cobra.Command, args []strin
 	}
 
 	for _, commit := range commitList {
+		// to bypass gosec check of overflow risk
+		if commit.NumPubRand > uint64(math.MaxUint32) {
+			return fmt.Errorf("NumPubRand %d exceeds maximum uint32 value", commit.NumPubRand)
+		}
+
 		pubRandList, err := em.CreateRandomnessPairList(fpPk.MustMarshal(), []byte(storedFp.ChainID), commit.StartHeight, uint32(commit.NumPubRand))
 		if err != nil {
 			return fmt.Errorf("failed to get randomness from height %d to height %d: %w", commit.StartHeight, commit.EndHeight(), err)

--- a/finality-provider/cmd/fpd/daemon/recover_proof.go
+++ b/finality-provider/cmd/fpd/daemon/recover_proof.go
@@ -1,0 +1,118 @@
+package daemon
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"path/filepath"
+
+	bbntypes "github.com/babylonlabs-io/babylon/types"
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/spf13/cobra"
+
+	"github.com/babylonlabs-io/finality-provider/clientcontroller/babylon"
+	eotsclient "github.com/babylonlabs-io/finality-provider/eotsmanager/client"
+	fpcmd "github.com/babylonlabs-io/finality-provider/finality-provider/cmd"
+	fpcfg "github.com/babylonlabs-io/finality-provider/finality-provider/config"
+	"github.com/babylonlabs-io/finality-provider/finality-provider/store"
+	"github.com/babylonlabs-io/finality-provider/log"
+	"github.com/babylonlabs-io/finality-provider/types"
+	"github.com/babylonlabs-io/finality-provider/util"
+)
+
+func CommandRecoverProof() *cobra.Command {
+	var cmd = &cobra.Command{
+		Use:     "recover-rand-proof [fp-eots-pk-hex]",
+		Aliases: []string{"rrp"},
+		Short:   "Recover the public randomness' merkle proof for a finality provider",
+		Long:    "Recover the public randomness' merkle proof for a finality provider. Currently only Babylon consumer chain is supported.",
+		Example: `fpd recover-rand-proof --home /home/user/.fpd [fp-eots-pk-hex]`,
+		Args:    cobra.ExactArgs(1),
+		RunE:    fpcmd.RunEWithClientCtx(runCommandRecoverProof),
+	}
+	cmd.Flags().Uint64("start-height", math.MaxUint64, "The block height from which the proof is recovered from (optional)")
+
+	return cmd
+}
+
+func runCommandRecoverProof(ctx client.Context, cmd *cobra.Command, args []string) error {
+	fpPk, err := bbntypes.NewBIP340PubKeyFromHex(args[0])
+	if err != nil {
+		return err
+	}
+	startHeight, err := cmd.Flags().GetUint64("start-height")
+	if err != nil {
+		return err
+	}
+
+	// Get homePath from context like in start.go
+	homePath, err := filepath.Abs(ctx.HomeDir)
+	if err != nil {
+		return err
+	}
+	homePath = util.CleanAndExpandPath(homePath)
+
+	cfg, err := fpcfg.LoadConfig(homePath)
+	if err != nil {
+		return fmt.Errorf("failed to load configuration: %w", err)
+	}
+
+	logger, err := log.NewRootLoggerWithFile(fpcfg.LogFile(homePath), cfg.LogLevel)
+	if err != nil {
+		return fmt.Errorf("failed to initialize the logger: %w", err)
+	}
+
+	db, err := cfg.DatabaseConfig.GetDBBackend()
+	if err != nil {
+		return fmt.Errorf("failed to create db backend: %w", err)
+	}
+
+	fpStore, err := store.NewFinalityProviderStore(db)
+	if err != nil {
+		return fmt.Errorf("failed to initiate finality provider store: %w", err)
+	}
+
+	storedFp, err := fpStore.GetFinalityProvider(fpPk.MustToBTCPK())
+	if err != nil {
+		return fmt.Errorf("failed to load fp %s from db: %w", fpPk.MarshalHex(), err)
+	}
+
+	pubRandStore, err := store.NewPubRandProofStore(db)
+	if err != nil {
+		return fmt.Errorf("failed to initiate public randomness store: %w", err)
+	}
+
+	em, err := eotsclient.NewEOTSManagerGRpcClient(cfg.EOTSManagerAddress)
+	if err != nil {
+		return fmt.Errorf("failed to create EOTS manager client: %w", err)
+	}
+
+	bcc, err := babylon.NewBabylonConsumerController(cfg.BabylonConfig, &cfg.BTCNetParams, logger)
+	if err != nil {
+		return fmt.Errorf("failed to create Babylon rpc client: %w", err)
+	}
+
+	commitList, err := bcc.QueryPublicRandCommitList(fpPk.MustToBTCPK(), startHeight)
+	if err != nil {
+		return fmt.Errorf("failed to query randomness commit list for fp %s: %w", fpPk.MarshalHex(), err)
+	}
+
+	for _, commit := range commitList {
+		pubRandList, err := em.CreateRandomnessPairList(fpPk.MustMarshal(), []byte(storedFp.ChainID), commit.StartHeight, uint32(commit.NumPubRand))
+		if err != nil {
+			return fmt.Errorf("failed to get randomness from height %d to height %d: %w", commit.StartHeight, commit.EndHeight(), err)
+		}
+		// generate commitment and proof for each public randomness
+		commitRoot, proofList := types.GetPubRandCommitAndProofs(pubRandList)
+		if !bytes.Equal(commitRoot, commit.Commitment) {
+			return fmt.Errorf("the commit root on Babylon does not match the local one, expected: %x, got: %x", commit.Commitment, commitRoot)
+		}
+
+		// store them to database
+		if err := pubRandStore.AddPubRandProofList(fpPk.MustMarshal(), []byte(storedFp.ChainID), commit.StartHeight, commit.NumPubRand, proofList); err != nil {
+			return fmt.Errorf("failed to save public randomness to DB: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/finality-provider/cmd/fpd/daemon/recover_proof.go
+++ b/finality-provider/cmd/fpd/daemon/recover_proof.go
@@ -75,6 +75,12 @@ func runCommandRecoverProof(ctx client.Context, cmd *cobra.Command, args []strin
 	}
 
 	db, err := cfg.DatabaseConfig.GetDBBackend()
+	defer func() {
+		err := db.Close()
+		if err != nil {
+			panic(fmt.Errorf("failed to close db: %w", err))
+		}
+	}()
 	if err != nil {
 		return fmt.Errorf("failed to create db backend: %w", err)
 	}

--- a/finality-provider/cmd/fpd/main.go
+++ b/finality-provider/cmd/fpd/main.go
@@ -38,7 +38,7 @@ func main() {
 		daemon.CommandInit(), daemon.CommandStart(), daemon.CommandKeys(),
 		daemon.CommandGetDaemonInfo(), daemon.CommandCreateFP(), daemon.CommandLsFP(),
 		daemon.CommandInfoFP(), daemon.CommandAddFinalitySig(), daemon.CommandUnjailFP(),
-		daemon.CommandEditFinalityDescription(), daemon.CommandCommitPubRand(),
+		daemon.CommandEditFinalityDescription(), daemon.CommandCommitPubRand(), daemon.CommandRecoverProof(),
 		incentivecli.NewWithdrawRewardCmd(), incentivecli.NewSetWithdrawAddressCmd(),
 		version.CommandVersion("fpd"), daemon.CommandUnsafePruneMerkleProof(),
 	)

--- a/finality-provider/config/db.go
+++ b/finality-provider/config/db.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	defaultDBName = "finality-provider.db"
+	DefaultDBName = "finality-provider.db"
 )
 
 type DBConfig struct {
@@ -47,7 +47,7 @@ func DefaultDBConfig() *DBConfig {
 func DefaultDBConfigWithHomePath(homePath string) *DBConfig {
 	return &DBConfig{
 		DBPath:            DataDir(homePath),
-		DBFileName:        defaultDBName,
+		DBFileName:        DefaultDBName,
 		NoFreelistSync:    true,
 		AutoCompact:       false,
 		AutoCompactMinAge: kvdb.DefaultBoltAutoCompactMinAge,

--- a/finality-provider/service/fp_instance.go
+++ b/finality-provider/service/fp_instance.go
@@ -662,7 +662,8 @@ func (fp *FinalityProviderInstance) SubmitBatchFinalitySignatures(blocks []*type
 		uint64(numPubRand),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get public randomness inclusion proof list: %w", err)
+		return nil, fmt.Errorf("failed to get public randomness inclusion proof list: %w\n"+
+			"Please recover the randomness proof from db.", err)
 	}
 
 	// sign blocks

--- a/finality-provider/service/fp_instance.go
+++ b/finality-provider/service/fp_instance.go
@@ -662,7 +662,7 @@ func (fp *FinalityProviderInstance) SubmitBatchFinalitySignatures(blocks []*type
 		uint64(numPubRand),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get public randomness inclusion proof list: %w\nPlease recover the randomness proof from db.", err)
+		return nil, fmt.Errorf("failed to get public randomness inclusion proof list: %w\nplease recover the randomness proof from db", err)
 	}
 
 	// sign blocks

--- a/finality-provider/service/fp_instance.go
+++ b/finality-provider/service/fp_instance.go
@@ -662,8 +662,7 @@ func (fp *FinalityProviderInstance) SubmitBatchFinalitySignatures(blocks []*type
 		uint64(numPubRand),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get public randomness inclusion proof list: %w\n"+
-			"Please recover the randomness proof from db.", err)
+		return nil, fmt.Errorf("failed to get public randomness inclusion proof list: %w\nPlease recover the randomness proof from db.", err)
 	}
 
 	// sign blocks

--- a/itest/babylon/babylon_e2e_test.go
+++ b/itest/babylon/babylon_e2e_test.go
@@ -1,5 +1,5 @@
-//go:build e2e_op
-// +build e2e_op
+//go:build e2e_babylon
+// +build e2e_babylon
 
 package e2etest_babylon
 

--- a/itest/babylon/babylon_e2e_test.go
+++ b/itest/babylon/babylon_e2e_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/babylonlabs-io/babylon/testutil/datagen"
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
-	"github.com/jessevdk/go-flags"
+	goflags "github.com/jessevdk/go-flags"
 	"github.com/stretchr/testify/require"
 
 	sdkmath "cosmossdk.io/math"
@@ -393,8 +393,8 @@ func TestPrintEotsCmd(t *testing.T) {
 	cmd := eotscmd.CommandPrintAllKeys()
 
 	defaultConfig := eotscfg.DefaultConfigWithHomePath(tm.EOTSHomeDir)
-	fileParser := flags.NewParser(defaultConfig, flags.Default)
-	err := flags.NewIniParser(fileParser).WriteFile(eotscfg.CfgFile(tm.EOTSHomeDir), flags.IniIncludeDefaults)
+	fileParser := goflags.NewParser(defaultConfig, goflags.Default)
+	err := goflags.NewIniParser(fileParser).WriteFile(eotscfg.CfgFile(tm.EOTSHomeDir), goflags.IniIncludeDefaults)
 	require.NoError(t, err)
 
 	cmd.SetArgs([]string{
@@ -463,8 +463,8 @@ func TestRecoverRandProofCmd(t *testing.T) {
 
 	fpCfg.EOTSManagerAddress = tm.EOTSServerHandler.Config().RPCListener
 	fpHomePath := filepath.Dir(fpCfg.DatabaseConfig.DBPath)
-	fileParser := flags.NewParser(fpCfg, flags.Default)
-	err = flags.NewIniParser(fileParser).WriteFile(cfg.CfgFile(fpHomePath), flags.IniIncludeDefaults)
+	fileParser := goflags.NewParser(fpCfg, goflags.Default)
+	err = goflags.NewIniParser(fileParser).WriteFile(cfg.CfgFile(fpHomePath), goflags.IniIncludeDefaults)
 	require.NoError(t, err)
 
 	// run the cmd

--- a/itest/babylon/babylon_e2e_test.go
+++ b/itest/babylon/babylon_e2e_test.go
@@ -1,5 +1,5 @@
-//go:build e2e_babylon
-// +build e2e_babylon
+//go:build e2e_op
+// +build e2e_op
 
 package e2etest_babylon
 
@@ -448,12 +448,6 @@ func TestRecoverRandProofCmd(t *testing.T) {
 	dbPath := filepath.Join(fpCfg.DatabaseConfig.DBPath, fpCfg.DatabaseConfig.DBFileName)
 	err = os.Remove(dbPath)
 	require.NoError(t, err)
-	fpdb, err := fpCfg.DatabaseConfig.GetDBBackend()
-	require.NoError(t, err)
-	pubRandStore, err := store.NewPubRandProofStore(fpdb)
-	require.NoError(t, err)
-	_, err = pubRandStore.GetPubRandProof([]byte(testChainID), fpIns.GetBtcPkBIP340().MustMarshal(), finalizedBlock.Height)
-	require.ErrorIs(t, err, store.ErrPubRandProofNotFound)
 
 	fpCfg.EOTSManagerAddress = tm.EOTSServerHandler.Config().RPCListener
 	fpHomePath := filepath.Dir(fpCfg.DatabaseConfig.DBPath)
@@ -475,10 +469,10 @@ func TestRecoverRandProofCmd(t *testing.T) {
 	_, err = os.Stat(dbPath)
 	require.NoError(t, err)
 
-	fpdb, err = fpCfg.DatabaseConfig.GetDBBackend()
+	fpdb, err := fpCfg.DatabaseConfig.GetDBBackend()
 	require.NoError(t, err)
 
-	pubRandStore, err = store.NewPubRandProofStore(fpdb)
+	pubRandStore, err := store.NewPubRandProofStore(fpdb)
 	require.NoError(t, err)
 	_, err = pubRandStore.GetPubRandProof([]byte(testChainID), fpIns.GetBtcPkBIP340().MustMarshal(), finalizedBlock.Height)
 	require.NoError(t, err)

--- a/itest/eotsmanager_handler.go
+++ b/itest/eotsmanager_handler.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/jessevdk/go-flags"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
@@ -27,6 +28,11 @@ func NewEOTSServerHandler(t *testing.T, cfg *config.Config, eotsHomeDir string) 
 	loggerConfig.Level = zap.NewAtomicLevelAt(zap.InfoLevel)
 	logger, err := loggerConfig.Build()
 	require.NoError(t, err)
+
+	fileParser := flags.NewParser(cfg, flags.Default)
+	err = flags.NewIniParser(fileParser).WriteFile(config.CfgFile(eotsHomeDir), flags.IniIncludeComments|flags.IniIncludeDefaults)
+	require.NoError(t, err)
+
 	eotsManager, err := eotsmanager.NewLocalEOTSManager(eotsHomeDir, cfg.KeyringBackend, dbBackend, logger)
 	require.NoError(t, err)
 


### PR DESCRIPTION
Closes #293. In particular, this PR:
- added a new cmd `recover-rand-proof --start-height` which checks the randomness commit on Babylon, re-generate randomness proof, and stores it in db.
- to check the randomness commit on babylon, a new query `QueryPublicRandCommitList` is added to babylon consumer client
- Note that this cmd currently only works for babylon consumer chain
- updated operational doc