### PR TITLE
[Backport] fix: withdrawal cli for rewards fp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,7 @@ verifies if there is a eots client running
 
 * [#199](https://github.com/babylonlabs-io/finality-provider/pull/199) EOTS signing for multiple finality providers
 * [#203](https://github.com/babylonlabs-io/finality-provider/pull/203) fpd cli: Withdraw rewards and set withdraw addr
+* [#231](https://github.com/babylonlabs-io/finality-provider/pull/231) fix: withdrawal cli for rewards fp
 
 ## v0.13.0
 

--- a/finality-provider/cmd/cmd.go
+++ b/finality-provider/cmd/cmd.go
@@ -8,6 +8,8 @@ import (
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/std"
+	"github.com/cosmos/cosmos-sdk/x/auth/types"
+	incentivetypes "github.com/babylonlabs-io/babylon/x/incentive/types"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
@@ -22,13 +24,16 @@ func PersistClientCtx(ctx client.Context) func(cmd *cobra.Command, _ []string) e
 		encCfg := params.DefaultEncodingConfig()
 		std.RegisterInterfaces(encCfg.InterfaceRegistry)
 		bstypes.RegisterInterfaces(encCfg.InterfaceRegistry)
+		incentivetypes.RegisterInterfaces(encCfg.InterfaceRegistry)
+		types.RegisterInterfaces(encCfg.InterfaceRegistry)
 
 		ctx = ctx.
 			WithCodec(encCfg.Codec).
 			WithInterfaceRegistry(encCfg.InterfaceRegistry).
 			WithTxConfig(encCfg.TxConfig).
 			WithLegacyAmino(encCfg.Amino).
-			WithInput(os.Stdin)
+			WithInput(os.Stdin).
+			WithAccountRetriever(types.AccountRetriever{})
 
 		// set the default command outputs
 		cmd.SetOut(cmd.OutOrStdout())

--- a/finality-provider/config/babylon.go
+++ b/finality-provider/config/babylon.go
@@ -40,7 +40,7 @@ func DefaultBBNConfig() BBNConfig {
 		// Setting this to relatively low value, out current babylon client (lens) will
 		// block for this amout of time to wait for transaction inclusion in block
 		BlockTimeout: 1 * time.Minute,
-		OutputFormat: dc.OutputFormat,
+		OutputFormat: "text",
 		SignModeStr:  dc.SignModeStr,
 	}
 }


### PR DESCRIPTION
Currently there is an error when trying to set the withdrawal address this pr:

fixes the error and allows to set an alternative withdrawal address
fixes the formatting of the output when withdrawing
closes: https://github.com/babylonlabs-io/finality-provider/issues/353