### PR TITLE
fix: check excluded methods with full names instead of prefixes and remove env variable requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Improvements
 
-* [#374](https://github.com/babylonlabs-io/finality-provider/pull/374) Check HMAC excluded methods by full proto names.
+* [#374](https://github.com/babylonlabs-io/finality-provider/pull/374) HMAC proto match and remove env requirement.
 * [#372](https://github.com/babylonlabs-io/finality-provider/pull/372) Add expected errors to finality vote sending. 
 * [#364](https://github.com/babylonlabs-io/finality-provider/pull/364) HMAC authentication service between fpd and eotsd.
 * [#335](https://github.com/babylonlabs-io/finality-provider/pull/335) chore: fix CosmWasm controller

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Improvements
 
+* [#374](https://github.com/babylonlabs-io/finality-provider/pull/374) Check HMAC excluded methods by full proto names.
 * [#364](https://github.com/babylonlabs-io/finality-provider/pull/364) HMAC authentication service between fpd and eotsd.
 * [#335](https://github.com/babylonlabs-io/finality-provider/pull/335) chore: fix CosmWasm controller
 * [#331](https://github.com/babylonlabs-io/finality-provider/pull/331) Bump Cosmos integration dependencies

--- a/docs/hmac-security.md
+++ b/docs/hmac-security.md
@@ -27,7 +27,7 @@ and does *not* use gRPC.  Therefore, key creation does *not* use or require HMAC
 
 ## Configuring HMAC Authentication
 
-HMAC authentication is strongly recommended for production deployments.  It relies on a shared secret key 
+HMAC authentication is strongly recommended for production deployments. It relies on a shared secret key 
 (the HMAC key) known to both FPD and EOTSD.
 
 ### Generating a Strong HMAC Key
@@ -44,8 +44,8 @@ Example output: Wt+Nxkn1DpNCFJtxQSxTKoSoKzx1C9XwHTMbT6ir9m0= (Your key will be d
 
 ## Configuration Methods
 
-### 1. FPD (fpd.conf - Recommended):
-The preferred method is to set the hmackey option within your fpd.conf file:
+### 1. FPD Configuration (fpd.conf):
+Set the hmackey option within your fpd.conf file:
 
 ```
 [metrics]
@@ -54,36 +54,29 @@ The preferred method is to set the hmackey option within your fpd.conf file:
 hmackey=Wt+Nxkn1DpNCFJtxQSxTKoSoKzx1C9XwHTMbT6ir9m0=  # Your base64 encoded key
 ```
 
-### 2. EOTSD (Environment Variable - Required):
+### 2. EOTSD Configuration (eotsd.conf):
 
-EOTSD exclusively reads the HMAC key from the HMAC_KEY environment variable. There is no configuration file 
-option for EOTSD. You must set this:
+Set the hmackey option within your eotsd.conf file:
 
 ```
-export HMAC_KEY="Wt+Nxkn1DpNCFJtxQSxTKoSoKzx1C9XwHTMbT6ir9m0="  # MUST match the FPD key, base64 encoded
+hmackey=Wt+Nxkn1DpNCFJtxQSxTKoSoKzx1C9XwHTMbT6ir9m0=  # MUST match the FPD key, base64 encoded
 ```
-
 
 ### Important Considerations:
 
 - Consistency: The HMAC key must be identical for both FPD and EOTSD.
 
-- fpd.conf Priority: If hmackey is set in fpd.conf, the HMAC_KEY environment variable is ignored by FPD. 
-The configuration file takes precedence.
-
 - Security: Never commit the HMAC key to version control. Store it securely, treating it like a private key.
 
-- If No Key is Provided: If no key is set (either via the config or via the environment), fpd will still start, 
-but with gRPC authentication turned off.
-
+- If No Key is Provided: If no key is set in the configuration, the services will still start, but with gRPC authentication turned off. This is not recommended for production environments.
 
 ## Deployment Best Practices
 
 Separate Machines: For maximum security, run FPD and EOTSD on separate machines. Restrict network access to the EOTSD
 machine, allowing connections only from the FPD instance.
 
-Key Rotation: Rotate the HMAC key periodically (e.g., every few months). Generate a new key, update the fpd.conf 
-file (and/or the HMAC_KEY environment variable), and restart both services. This requires a brief downtime.
+Key Rotation: Rotate the HMAC key periodically (e.g., every few months). Generate a new key, update the configuration
+files, and restart both services. This requires a brief downtime.
 
 ## Troubleshooting
 
@@ -92,21 +85,6 @@ If you encounter HMAC authentication errors:
 1. Key Mismatch: The most common cause is a difference between the HMAC keys configured for FPD and EOTSD. 
 Double-check that they are identical, including any leading or trailing whitespace.
 
-2. Environment Variable Issues:
+2. Configuration Issues: Ensure that the HMAC key is properly set in both configuration files.
 
-   - Ensure the HMAC_KEY environment variable is correctly set in the environment where eotsd is running.
-
-   - If using systemd or a similar service manager, make sure the environment variable is set within the service 
-   definition, not just in your interactive shell.
-
-   - If using fpd.conf, make sure the hmackey is set correctly, and that no HMAC_KEY environment variable with 
-   an incorrect value is present (as it will be ignored if hmackey is set).
-
-3. Logs: Check the logs of both FPD and EOTSD for error messages related to HMAC. Look for "invalid HMAC."
-
-4. Connectivity: Use the Ping method (which bypasses HMAC) to test basic network connectivity between FPD and EOTSD.
-
-5. Restart: After making any configuration changes, restart both FPD and EOTSD.
-
-By following these guidelines, you can secure the communication between FPD and EOTSD, protecting your finality 
-provider from unauthorized signature requests and potential slashing events.
+3. Cloud Secret References: If you're using cloud secret references (AWS, GCP, Azure), ensure they are properly formatted and accessible.

--- a/docs/hmac-security.md
+++ b/docs/hmac-security.md
@@ -102,7 +102,7 @@ Double-check that they are identical, including any leading or trailing whitespa
    - If using fpd.conf, make sure the hmackey is set correctly, and that no HMAC_KEY environment variable with 
    an incorrect value is present (as it will be ignored if hmackey is set).
 
-3. Logs: Check the logs of both FPD and EOTSD for error messages related to HMAC. Look for "invalid HMAC signature."
+3. Logs: Check the logs of both FPD and EOTSD for error messages related to HMAC. Look for "invalid HMAC."
 
 4. Connectivity: Use the Ping method (which bypasses HMAC) to test basic network connectivity between FPD and EOTSD.
 

--- a/eotsmanager/client/hmac.go
+++ b/eotsmanager/client/hmac.go
@@ -33,26 +33,21 @@ func HMACUnaryClientInterceptor(hmacKey string) grpc.UnaryClientInterceptor {
 		// NOTE: SaveEOTSKeyName is a local key management operation that doesn't require HMAC
 		switch method {
 		case "/proto.EOTSManager/Ping", "/proto.EOTSManager/SaveEOTSKeyName":
-
 			return invoker(ctx, method, req, reply, cc, opts...)
 		}
 
 		// If HMAC key is empty, skip authentication
 		if hmacKey == "" {
-			fmt.Printf("HMAC authentication disabled for client: empty HMAC key\n")
 			return invoker(ctx, method, req, reply, cc, opts...)
 		}
 
 		msg, ok := req.(proto.Message)
 		if !ok {
-			fmt.Printf("HMAC generation failed: request is not a protobuf message\n")
-
 			return fmt.Errorf("request is not a protobuf message")
 		}
 
 		data, err := proto.Marshal(msg)
 		if err != nil {
-			fmt.Printf("HMAC generation failed: failed to marshal request: %v\n", err)
 			return fmt.Errorf("failed to marshal request: %w", err)
 		}
 
@@ -70,9 +65,6 @@ func HMACUnaryClientInterceptor(hmacKey string) grpc.UnaryClientInterceptor {
 		}
 		md.Set(HMACHeaderKey, hmacValue)
 		newCtx := metadata.NewOutgoingContext(ctx, md)
-
-		fmt.Printf("HMAC added to client request for method: %s\n", method)
-		fmt.Printf("  HMAC value: %s\n", hmacValue)
 
 		return invoker(newCtx, method, req, reply, cc, opts...)
 	}

--- a/eotsmanager/client/hmac.go
+++ b/eotsmanager/client/hmac.go
@@ -16,7 +16,7 @@ import (
 const (
 	// HMACKeyEnvVar is the environment variable name for the HMAC key
 	HMACKeyEnvVar = "HMAC_KEY"
-	// HMACHeaderKey is the metadata key for the HMAC signature
+	// HMACHeaderKey is the metadata key for the HMAC
 	HMACHeaderKey = "X-FPD-HMAC"
 )
 

--- a/eotsmanager/client/hmac.go
+++ b/eotsmanager/client/hmac.go
@@ -33,6 +33,7 @@ func HMACUnaryClientInterceptor(hmacKey string) grpc.UnaryClientInterceptor {
 		// NOTE: SaveEOTSKeyName is a local key management operation that doesn't require HMAC
 		switch method {
 		case "/proto.EOTSManager/Ping", "/proto.EOTSManager/SaveEOTSKeyName":
+
 			return invoker(ctx, method, req, reply, cc, opts...)
 		}
 
@@ -45,13 +46,14 @@ func HMACUnaryClientInterceptor(hmacKey string) grpc.UnaryClientInterceptor {
 		msg, ok := req.(proto.Message)
 		if !ok {
 			fmt.Printf("HMAC generation failed: request is not a protobuf message\n")
+
 			return fmt.Errorf("request is not a protobuf message")
 		}
 
 		data, err := proto.Marshal(msg)
 		if err != nil {
 			fmt.Printf("HMAC generation failed: failed to marshal request: %v\n", err)
-			return fmt.Errorf("failed to marshal request: %v", err)
+			return fmt.Errorf("failed to marshal request: %w", err)
 		}
 
 		// Generate HMAC using SHA-256

--- a/eotsmanager/client/hmac.go
+++ b/eotsmanager/client/hmac.go
@@ -6,7 +6,6 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"fmt"
-	"os"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
@@ -14,24 +13,12 @@ import (
 )
 
 const (
-	// HMACKeyEnvVar is the environment variable name for the HMAC key
-	HMACKeyEnvVar = "HMAC_KEY"
 	// HMACHeaderKey is the metadata key for the HMAC
 	HMACHeaderKey = "X-FPD-HMAC"
 )
 
-// GetHMACKey retrieves the HMAC key from the environment variable
-func GetHMACKey() (string, error) {
-	key := os.Getenv(HMACKeyEnvVar)
-	if key == "" {
-		return "", fmt.Errorf("HMAC_KEY environment variable not set")
-	}
-
-	return key, nil
-}
-
 // HMACUnaryClientInterceptor creates a gRPC client interceptor that adds HMAC
-// to outgoing requests. It bypasses authentication for the Ping and SaveEOTSKeyName methods.
+// to outgoing requests. It skips adding HMAC for the Ping method and SaveEOTSKeyName.
 func HMACUnaryClientInterceptor(hmacKey string) grpc.UnaryClientInterceptor {
 	return func(
 		ctx context.Context,
@@ -42,37 +29,49 @@ func HMACUnaryClientInterceptor(hmacKey string) grpc.UnaryClientInterceptor {
 		opts ...grpc.CallOption,
 	) error {
 		// Skip authentication for specific methods using exact matching
-		// NOTE: We should disable hmac on pings to allow for health checks
+		// NOTE: we should disable hmac on pings to allow for health checks
 		// NOTE: SaveEOTSKeyName is a local key management operation that doesn't require HMAC
 		switch method {
 		case "/proto.EOTSManager/Ping", "/proto.EOTSManager/SaveEOTSKeyName":
 			return invoker(ctx, method, req, reply, cc, opts...)
 		}
 
+		// If HMAC key is empty, skip authentication
+		if hmacKey == "" {
+			fmt.Printf("HMAC authentication disabled for client: empty HMAC key\n")
+			return invoker(ctx, method, req, reply, cc, opts...)
+		}
+
 		msg, ok := req.(proto.Message)
 		if !ok {
-			return invoker(ctx, method, req, reply, cc, opts...)
+			fmt.Printf("HMAC generation failed: request is not a protobuf message\n")
+			return fmt.Errorf("request is not a protobuf message")
 		}
 
 		data, err := proto.Marshal(msg)
 		if err != nil {
-			return err
+			fmt.Printf("HMAC generation failed: failed to marshal request: %v\n", err)
+			return fmt.Errorf("failed to marshal request: %v", err)
 		}
 
 		// Generate HMAC using SHA-256
 		h := hmac.New(sha256.New, []byte(hmacKey))
 		h.Write(data)
-		hmacString := base64.StdEncoding.EncodeToString(h.Sum(nil))
+		hmacValue := base64.StdEncoding.EncodeToString(h.Sum(nil))
 
-		// Add HMAC to the context metadata
+		// Add HMAC to outgoing context
 		md, ok := metadata.FromOutgoingContext(ctx)
 		if !ok {
 			md = metadata.New(nil)
+		} else {
+			md = md.Copy()
 		}
-		md = md.Copy()
-		md.Set(HMACHeaderKey, hmacString)
-		ctx = metadata.NewOutgoingContext(ctx, md)
+		md.Set(HMACHeaderKey, hmacValue)
+		newCtx := metadata.NewOutgoingContext(ctx, md)
 
-		return invoker(ctx, method, req, reply, cc, opts...)
+		fmt.Printf("HMAC added to client request for method: %s\n", method)
+		fmt.Printf("  HMAC value: %s\n", hmacValue)
+
+		return invoker(newCtx, method, req, reply, cc, opts...)
 	}
 }

--- a/eotsmanager/client/secrets.go
+++ b/eotsmanager/client/secrets.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"fmt"
-	"os"
 	"strings"
 )
 
@@ -18,6 +17,10 @@ const (
 
 // GetSecretValue retrieves a secret value from various sources based on the reference format
 func GetSecretValue(reference string) (string, error) {
+	if reference == "" {
+		return "", nil
+	}
+
 	// If it's a reference to a cloud secret manager, fetch the secret
 	switch {
 	case strings.HasPrefix(reference, AWSPrefix):
@@ -31,14 +34,13 @@ func GetSecretValue(reference string) (string, error) {
 	}
 }
 
-// GetHMACKeyWithCloudSupport gets the HMAC key from environment or cloud secret managers
-func GetHMACKeyWithCloudSupport() (string, error) {
-	keyRef := os.Getenv(HMACKeyEnvVar)
-	if keyRef == "" {
-		return "", fmt.Errorf("HMAC_KEY environment variable not set")
+// ProcessHMACKey processes the HMAC key, handling cloud secret references if needed
+func ProcessHMACKey(hmacKey string) (string, error) {
+	if hmacKey == "" {
+		return "", nil
 	}
 
-	return GetSecretValue(keyRef)
+	return GetSecretValue(hmacKey)
 }
 
 // getAWSSecret gets a secret from AWS secrets manager
@@ -56,8 +58,8 @@ func getGCPSecret(secretName string) (string, error) {
 }
 
 // getAzureSecret gets the secret from Azure Key Vault
-func getAzureSecret(secretURI string) (string, error) {
+func getAzureSecret(secretName string) (string, error) {
 	// TODO: Needs to be implemented
-	// NOTE: https://learn.microsoft.com/en-us/azure/key-vault/secrets/quick-create-go?tabs=azure-cli
-	return "", fmt.Errorf("azure key vault integration not implemented: %s", secretURI)
+	// NOTE: https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets
+	return "", fmt.Errorf("azure key vault integration not implemented: %s", secretName)
 }

--- a/eotsmanager/cmd/eotsd/daemon/keys.go
+++ b/eotsmanager/cmd/eotsd/daemon/keys.go
@@ -152,7 +152,7 @@ func saveKeyNameMapping(cmd *cobra.Command, keyName string) (*types.BIP340PubKey
 	}
 
 	if len(rpcListener) > 0 {
-		client, err := eotsclient.NewEOTSManagerGRpcClient(rpcListener)
+		client, err := eotsclient.NewEOTSManagerGRpcClient(rpcListener, "")
 		if err != nil {
 			return nil, err
 		}

--- a/eotsmanager/service/hmac.go
+++ b/eotsmanager/service/hmac.go
@@ -30,18 +30,21 @@ func HMACUnaryServerInterceptor(hmacKey string) grpc.UnaryServerInterceptor {
 		// NOTE: SaveEOTSKeyName is a local key management operation that doesn't require HMAC
 		switch info.FullMethod {
 		case "/proto.EOTSManager/Ping", "/proto.EOTSManager/SaveEOTSKeyName":
+
 			return handler(ctx, req)
 		}
 
 		// If HMAC key is empty, skip authentication
 		if hmacKey == "" {
 			fmt.Printf("HMAC authentication disabled: empty HMAC key\n")
+
 			return handler(ctx, req)
 		}
 
 		md, ok := metadata.FromIncomingContext(ctx)
 		if !ok {
 			fmt.Printf("HMAC authentication failed: metadata not provided\n")
+
 			return nil, status.Errorf(codes.Unauthenticated, "metadata is not provided")
 		}
 
@@ -49,6 +52,7 @@ func HMACUnaryServerInterceptor(hmacKey string) grpc.UnaryServerInterceptor {
 		values := md.Get(client.HMACHeaderKey)
 		if len(values) == 0 {
 			fmt.Printf("HMAC authentication failed: HMAC header not provided\n")
+
 			return nil, status.Errorf(codes.Unauthenticated, "HMAC not provided")
 		}
 		receivedHMAC := values[0]
@@ -56,12 +60,14 @@ func HMACUnaryServerInterceptor(hmacKey string) grpc.UnaryServerInterceptor {
 		msg, ok := req.(proto.Message)
 		if !ok {
 			fmt.Printf("HMAC authentication failed: request is not a protobuf message\n")
+
 			return nil, status.Errorf(codes.Internal, "request is not a protobuf message")
 		}
 
 		data, err := proto.Marshal(msg)
 		if err != nil {
 			fmt.Printf("HMAC authentication failed: failed to marshal request: %v\n", err)
+
 			return nil, status.Errorf(codes.Internal, "failed to marshal request: %v", err)
 		}
 
@@ -76,10 +82,12 @@ func HMACUnaryServerInterceptor(hmacKey string) grpc.UnaryServerInterceptor {
 			fmt.Printf("  Method: %s\n", info.FullMethod)
 			fmt.Printf("  Expected: %s\n", expectedHMAC)
 			fmt.Printf("  Received: %s\n", receivedHMAC)
+
 			return nil, status.Errorf(codes.Unauthenticated, "invalid HMAC")
 		}
 
 		fmt.Printf("HMAC authentication succeeded for method: %s\n", info.FullMethod)
+
 		return handler(ctx, req)
 	}
 }

--- a/eotsmanager/service/hmac.go
+++ b/eotsmanager/service/hmac.go
@@ -27,7 +27,7 @@ func GetHMACKeyFromEnv() (string, error) {
 	return key, nil
 }
 
-// HMACUnaryServerInterceptor creates a gRPC server interceptor that verifies HMAC signatures
+// HMACUnaryServerInterceptor creates a gRPC server interceptor that verifies HMAC
 // on incoming requests. It bypasses authentication for the Ping method and SaveEOTSKeyName.
 func HMACUnaryServerInterceptor(hmacKey string) grpc.UnaryServerInterceptor {
 	return func(
@@ -52,7 +52,7 @@ func HMACUnaryServerInterceptor(hmacKey string) grpc.UnaryServerInterceptor {
 		// Get HMAC from metadata
 		values := md.Get(client.HMACHeaderKey)
 		if len(values) == 0 {
-			return nil, status.Errorf(codes.Unauthenticated, "HMAC signature not provided")
+			return nil, status.Errorf(codes.Unauthenticated, "HMAC not provided")
 		}
 		receivedHMAC := values[0]
 

--- a/eotsmanager/service/hmac.go
+++ b/eotsmanager/service/hmac.go
@@ -7,7 +7,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"os"
-	"strings"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -37,10 +36,11 @@ func HMACUnaryServerInterceptor(hmacKey string) grpc.UnaryServerInterceptor {
 		info *grpc.UnaryServerInfo,
 		handler grpc.UnaryHandler,
 	) (interface{}, error) {
-		// Skip authentication for Ping method and SaveEOTSKeyName (local key management)
+		// Skip authentication for specific methods using exact matching
 		// NOTE: we should disable hmac on pings to allow for health checks
 		// NOTE: SaveEOTSKeyName is a local key management operation that doesn't require HMAC
-		if strings.HasSuffix(info.FullMethod, "/Ping") || strings.HasSuffix(info.FullMethod, "/SaveEOTSKeyName") {
+		switch info.FullMethod {
+		case "/proto.EOTSManager/Ping", "/proto.EOTSManager/SaveEOTSKeyName":
 			return handler(ctx, req)
 		}
 

--- a/eotsmanager/service/hmac.go
+++ b/eotsmanager/service/hmac.go
@@ -5,8 +5,6 @@ import (
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/base64"
-	"fmt"
-
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
@@ -36,38 +34,28 @@ func HMACUnaryServerInterceptor(hmacKey string) grpc.UnaryServerInterceptor {
 
 		// If HMAC key is empty, skip authentication
 		if hmacKey == "" {
-			fmt.Printf("HMAC authentication disabled: empty HMAC key\n")
-
 			return handler(ctx, req)
 		}
 
 		md, ok := metadata.FromIncomingContext(ctx)
 		if !ok {
-			fmt.Printf("HMAC authentication failed: metadata not provided\n")
-
 			return nil, status.Errorf(codes.Unauthenticated, "metadata is not provided")
 		}
 
 		// Get HMAC from metadata
 		values := md.Get(client.HMACHeaderKey)
 		if len(values) == 0 {
-			fmt.Printf("HMAC authentication failed: HMAC header not provided\n")
-
 			return nil, status.Errorf(codes.Unauthenticated, "HMAC not provided")
 		}
 		receivedHMAC := values[0]
 
 		msg, ok := req.(proto.Message)
 		if !ok {
-			fmt.Printf("HMAC authentication failed: request is not a protobuf message\n")
-
 			return nil, status.Errorf(codes.Internal, "request is not a protobuf message")
 		}
 
 		data, err := proto.Marshal(msg)
 		if err != nil {
-			fmt.Printf("HMAC authentication failed: failed to marshal request: %v\n", err)
-
 			return nil, status.Errorf(codes.Internal, "failed to marshal request: %v", err)
 		}
 
@@ -78,15 +66,8 @@ func HMACUnaryServerInterceptor(hmacKey string) grpc.UnaryServerInterceptor {
 
 		// Compare HMACs using constant-time comparison to avoid timing attacks
 		if !hmac.Equal([]byte(receivedHMAC), []byte(expectedHMAC)) {
-			fmt.Printf("HMAC authentication failed: invalid HMAC\n")
-			fmt.Printf("  Method: %s\n", info.FullMethod)
-			fmt.Printf("  Expected: %s\n", expectedHMAC)
-			fmt.Printf("  Received: %s\n", receivedHMAC)
-
 			return nil, status.Errorf(codes.Unauthenticated, "invalid HMAC")
 		}
-
-		fmt.Printf("HMAC authentication succeeded for method: %s\n", info.FullMethod)
 
 		return handler(ctx, req)
 	}

--- a/eotsmanager/service/hmac.go
+++ b/eotsmanager/service/hmac.go
@@ -73,7 +73,7 @@ func HMACUnaryServerInterceptor(hmacKey string) grpc.UnaryServerInterceptor {
 
 		// Compare HMACs using constant-time comparison to avoid timing attacks
 		if !hmac.Equal([]byte(receivedHMAC), []byte(expectedHMAC)) {
-			return nil, status.Errorf(codes.Unauthenticated, "invalid HMAC signature")
+			return nil, status.Errorf(codes.Unauthenticated, "invalid HMAC")
 		}
 
 		return handler(ctx, req)

--- a/eotsmanager/service/hmac.go
+++ b/eotsmanager/service/hmac.go
@@ -6,7 +6,6 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"fmt"
-	"os"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -16,16 +15,6 @@ import (
 
 	"github.com/babylonlabs-io/finality-provider/eotsmanager/client"
 )
-
-// GetHMACKeyFromEnv retrieves the HMAC key from the environment variable
-func GetHMACKeyFromEnv() (string, error) {
-	key := os.Getenv(client.HMACKeyEnvVar)
-	if key == "" {
-		return "", fmt.Errorf("HMAC_KEY environment variable not set")
-	}
-
-	return key, nil
-}
 
 // HMACUnaryServerInterceptor creates a gRPC server interceptor that verifies HMAC
 // on incoming requests. It bypasses authentication for the Ping method and SaveEOTSKeyName.
@@ -44,25 +33,35 @@ func HMACUnaryServerInterceptor(hmacKey string) grpc.UnaryServerInterceptor {
 			return handler(ctx, req)
 		}
 
+		// If HMAC key is empty, skip authentication
+		if hmacKey == "" {
+			fmt.Printf("HMAC authentication disabled: empty HMAC key\n")
+			return handler(ctx, req)
+		}
+
 		md, ok := metadata.FromIncomingContext(ctx)
 		if !ok {
+			fmt.Printf("HMAC authentication failed: metadata not provided\n")
 			return nil, status.Errorf(codes.Unauthenticated, "metadata is not provided")
 		}
 
 		// Get HMAC from metadata
 		values := md.Get(client.HMACHeaderKey)
 		if len(values) == 0 {
+			fmt.Printf("HMAC authentication failed: HMAC header not provided\n")
 			return nil, status.Errorf(codes.Unauthenticated, "HMAC not provided")
 		}
 		receivedHMAC := values[0]
 
 		msg, ok := req.(proto.Message)
 		if !ok {
+			fmt.Printf("HMAC authentication failed: request is not a protobuf message\n")
 			return nil, status.Errorf(codes.Internal, "request is not a protobuf message")
 		}
 
 		data, err := proto.Marshal(msg)
 		if err != nil {
+			fmt.Printf("HMAC authentication failed: failed to marshal request: %v\n", err)
 			return nil, status.Errorf(codes.Internal, "failed to marshal request: %v", err)
 		}
 
@@ -73,9 +72,14 @@ func HMACUnaryServerInterceptor(hmacKey string) grpc.UnaryServerInterceptor {
 
 		// Compare HMACs using constant-time comparison to avoid timing attacks
 		if !hmac.Equal([]byte(receivedHMAC), []byte(expectedHMAC)) {
+			fmt.Printf("HMAC authentication failed: invalid HMAC\n")
+			fmt.Printf("  Method: %s\n", info.FullMethod)
+			fmt.Printf("  Expected: %s\n", expectedHMAC)
+			fmt.Printf("  Received: %s\n", receivedHMAC)
 			return nil, status.Errorf(codes.Unauthenticated, "invalid HMAC")
 		}
 
+		fmt.Printf("HMAC authentication succeeded for method: %s\n", info.FullMethod)
 		return handler(ctx, req)
 	}
 }

--- a/eotsmanager/service/hmac_test.go
+++ b/eotsmanager/service/hmac_test.go
@@ -135,6 +135,7 @@ func TestMissingHMACHeader(t *testing.T) {
 }
 
 func TestConfigHMACKey(t *testing.T) {
+	t.Parallel()
 	testKey := "config-hmac-key"
 	cfg := &config.Config{
 		HMACKey: testKey,

--- a/eotsmanager/service/hmac_test.go
+++ b/eotsmanager/service/hmac_test.go
@@ -5,7 +5,6 @@ import (
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/base64"
-	"os"
 	"testing"
 
 	"github.com/babylonlabs-io/finality-provider/eotsmanager/service"
@@ -70,23 +69,6 @@ func TestHMACVerification(t *testing.T) {
 	)
 	require.Error(t, err)
 	require.Equal(t, codes.Unauthenticated, status.Code(err))
-}
-
-func TestHMACKeyRetrieval(t *testing.T) {
-	originalKey := os.Getenv(client.HMACKeyEnvVar)
-	defer t.Setenv(client.HMACKeyEnvVar, originalKey)
-
-	testKey := "test-hmac-secret-key"
-	t.Setenv(client.HMACKeyEnvVar, testKey)
-
-	key, err := client.GetHMACKey()
-	require.NoError(t, err)
-	require.Equal(t, testKey, key)
-
-	os.Unsetenv(client.HMACKeyEnvVar)
-	_, err = client.GetHMACKey()
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "environment variable not set")
 }
 
 func TestHMACAuthDisabled(t *testing.T) {
@@ -158,14 +140,4 @@ func TestConfigHMACKey(t *testing.T) {
 		HMACKey: testKey,
 	}
 	require.Equal(t, testKey, cfg.HMACKey)
-
-	originalKey := os.Getenv(client.HMACKeyEnvVar)
-	defer t.Setenv(client.HMACKeyEnvVar, originalKey)
-
-	envKey := "env-hmac-key"
-	t.Setenv(client.HMACKeyEnvVar, envKey)
-
-	key, err := client.GetHMACKey()
-	require.NoError(t, err)
-	require.Equal(t, envKey, key)
 }

--- a/eotsmanager/service/server.go
+++ b/eotsmanager/service/server.go
@@ -83,15 +83,10 @@ func (s *Server) RunUntilShutdown(ctx context.Context) error {
 		_ = lis.Close()
 	}()
 
-	// Get HMAC key from config or environment variable for cloud providers
-	// TODO: Make this a requirement by mainnet and error
+	// Get HMAC key from config
 	hmacKey := s.cfg.HMACKey
 	if hmacKey == "" {
-		var err error
-		hmacKey, err = GetHMACKeyFromEnv()
-		if err != nil {
-			s.logger.Warn("HMAC key not configured. Authentication will not be enabled.", zap.Error(err))
-		}
+		s.logger.Warn("HMAC key not configured in config. Authentication will not be enabled.")
 	}
 
 	var opts []grpc.ServerOption
@@ -143,4 +138,14 @@ func (s *Server) startGrpcListen(grpcServer *grpc.Server, listeners []net.Listen
 
 	// Wait for gRPC servers to be up running.
 	wg.Wait()
+}
+
+// GetLogger returns the server's logger
+func (s *Server) GetLogger() *zap.Logger {
+	return s.logger
+}
+
+// GetDB returns the server's database
+func (s *Server) GetDB() kvdb.Backend {
+	return s.db
 }

--- a/eotsmanager/service/server.go
+++ b/eotsmanager/service/server.go
@@ -139,13 +139,3 @@ func (s *Server) startGrpcListen(grpcServer *grpc.Server, listeners []net.Listen
 	// Wait for gRPC servers to be up running.
 	wg.Wait()
 }
-
-// GetLogger returns the server's logger
-func (s *Server) GetLogger() *zap.Logger {
-	return s.logger
-}
-
-// GetDB returns the server's database
-func (s *Server) GetDB() kvdb.Backend {
-	return s.db
-}

--- a/finality-provider/cmd/fpd/daemon/commit_pr.go
+++ b/finality-provider/cmd/fpd/daemon/commit_pr.go
@@ -93,7 +93,7 @@ func runCommandCommitPubRand(ctx client.Context, cmd *cobra.Command, args []stri
 	if err != nil {
 		return fmt.Errorf("failed to create rpc client for the consumer chain %s: %w", cfg.ChainType, err)
 	}
-	em, err := eotsclient.NewEOTSManagerGRpcClient(cfg.EOTSManagerAddress)
+	em, err := eotsclient.NewEOTSManagerGRpcClient(cfg.EOTSManagerAddress, cfg.HMACKey)
 	if err != nil {
 		return fmt.Errorf("failed to create EOTS manager client: %w", err)
 	}

--- a/finality-provider/cmd/fpd/daemon/recover_proof.go
+++ b/finality-provider/cmd/fpd/daemon/recover_proof.go
@@ -90,7 +90,7 @@ func runCommandRecoverProof(ctx client.Context, cmd *cobra.Command, args []strin
 		return fmt.Errorf("failed to initiate public randomness store: %w", err)
 	}
 
-	em, err := eotsclient.NewEOTSManagerGRpcClient(cfg.EOTSManagerAddress)
+	em, err := eotsclient.NewEOTSManagerGRpcClient(cfg.EOTSManagerAddress, cfg.HMACKey)
 	if err != nil {
 		return fmt.Errorf("failed to create EOTS manager client: %w", err)
 	}

--- a/finality-provider/service/eots_manager_adapter.go
+++ b/finality-provider/service/eots_manager_adapter.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	"fmt"
-	"os"
 
 	bbntypes "github.com/babylonlabs-io/babylon/types"
 	"github.com/btcsuite/btcd/btcec/v2"
@@ -17,14 +16,7 @@ import (
 
 // InitEOTSManagerClient initializes an EOTS manager client with HMAC authentication
 func InitEOTSManagerClient(address string, hmacKey string) (eotsmanager.EOTSManager, error) {
-	// If HMAC key is provided in config, set it in environment for the client to use
-	if hmacKey != "" {
-		if err := os.Setenv(client.HMACKeyEnvVar, hmacKey); err != nil {
-			return nil, fmt.Errorf("failed to set HMAC_KEY environment variable: %w", err)
-		}
-	}
-
-	return client.NewEOTSManagerGRpcClient(address)
+	return client.NewEOTSManagerGRpcClient(address, hmacKey)
 }
 
 func (fp *FinalityProviderInstance) GetPubRandList(startHeight uint64, numPubRand uint32) ([]*btcec.FieldVal, error) {

--- a/itest/babylon/babylon_e2e_test.go
+++ b/itest/babylon/babylon_e2e_test.go
@@ -83,20 +83,6 @@ func TestDoubleSigning(t *testing.T) {
 
 	fpIns := fps[0]
 
-	require.Eventually(t, func() bool {
-		_, err := tm.EOTSClient.CreateRandomnessPairList(
-			fpIns.GetBtcPkBIP340().MustMarshal(),
-			[]byte(testChainID),
-			1,
-			1,
-		)
-		if err != nil {
-			t.Logf("Key not ready yet for randomness generation: %v", err)
-			return false
-		}
-		return true
-	}, 30*time.Second, 500*time.Millisecond, "EOTS key not ready for randomness generation")
-
 	// check the public randomness is committed
 	tm.WaitForFpPubRandTimestamped(t, fpIns)
 

--- a/itest/babylon/babylon_e2e_test.go
+++ b/itest/babylon/babylon_e2e_test.go
@@ -83,6 +83,20 @@ func TestDoubleSigning(t *testing.T) {
 
 	fpIns := fps[0]
 
+	require.Eventually(t, func() bool {
+		_, err := tm.EOTSClient.CreateRandomnessPairList(
+			fpIns.GetBtcPkBIP340().MustMarshal(),
+			[]byte(testChainID),
+			1,
+			1,
+		)
+		if err != nil {
+			t.Logf("Key not ready yet for randomness generation: %v", err)
+			return false
+		}
+		return true
+	}, 30*time.Second, 500*time.Millisecond, "EOTS key not ready for randomness generation")
+
 	// check the public randomness is committed
 	tm.WaitForFpPubRandTimestamped(t, fpIns)
 

--- a/itest/babylon/babylon_e2e_test.go
+++ b/itest/babylon/babylon_e2e_test.go
@@ -369,7 +369,7 @@ func TestPrintEotsCmd(t *testing.T) {
 	t.Parallel()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	tm := StartManager(t, ctx)
+	tm := StartManager(t, ctx, "", "")
 	r := rand.New(rand.NewSource(time.Now().Unix()))
 	defer tm.Stop(t)
 

--- a/itest/babylon/babylon_test_manager.go
+++ b/itest/babylon/babylon_test_manager.go
@@ -215,6 +215,18 @@ func (tm *TestManager) AddFinalityProvider(t *testing.T, ctx context.Context, hm
 
 	t.Logf("the EOTS key is created: %s", eotsPk.MarshalHex())
 
+	// Ensure key is properly saved in EOTS server
+	require.Eventually(t, func() bool {
+		err := tm.EOTSClient.SaveEOTSKeyName(eotsPk.MustToBTCPK(), eotsKeyName)
+		if err != nil {
+			t.Logf("Failed to save EOTS key name: %v, retrying...", err)
+			time.Sleep(500 * time.Millisecond)
+			return false
+		}
+		return true
+	}, 60*time.Second, time.Second, "Failed to save EOTS key name")
+
+	// Verify key is ready by attempting to create randomness pairs
 	require.Eventually(t, func() bool {
 		_, err := tm.EOTSClient.CreateRandomnessPairList(eotsPk.MustMarshal(), []byte(testChainID), 0, 1)
 		if err != nil {

--- a/itest/babylon/babylon_test_manager.go
+++ b/itest/babylon/babylon_test_manager.go
@@ -204,11 +204,11 @@ func (tm *TestManager) AddFinalityProvider(t *testing.T, ctx context.Context, hm
 		eotsPkBz, err = tm.EOTSServerHandler.CreateKey(eotsKeyName)
 		if err != nil {
 			t.Logf("Failed to create EOTS key: %v, retrying...", err)
-			time.Sleep(100 * time.Millisecond)
+			time.Sleep(500 * time.Millisecond)
 			return false
 		}
 		return true
-	}, 30*time.Second, 500*time.Millisecond, "Failed to create EOTS key after multiple attempts")
+	}, 60*time.Second, time.Second, "Failed to create EOTS key after multiple attempts")
 
 	eotsPk, err := bbntypes.NewBIP340PubKey(eotsPkBz)
 	require.NoError(t, err)
@@ -219,10 +219,11 @@ func (tm *TestManager) AddFinalityProvider(t *testing.T, ctx context.Context, hm
 		_, err := tm.EOTSClient.CreateRandomnessPairList(eotsPk.MustMarshal(), []byte(testChainID), 0, 1)
 		if err != nil {
 			t.Logf("EOTS key is not yet ready: %v, waiting...", err)
+			time.Sleep(500 * time.Millisecond)
 			return false
 		}
 		return true
-	}, 30*time.Second, 500*time.Millisecond, "EOTS key not ready after waiting")
+	}, 60*time.Second, time.Second, "EOTS key not ready after waiting")
 
 	// Create FP babylon key
 	fpKeyName := fmt.Sprintf("fp-key-%s", datagen.GenRandomHexStr(r, 4))

--- a/itest/babylon/babylon_test_manager.go
+++ b/itest/babylon/babylon_test_manager.go
@@ -33,7 +33,7 @@ import (
 
 const (
 	eventuallyWaitTimeOut = 5 * time.Minute
-	eventuallyPollTime    = 500 * time.Millisecond
+	eventuallyPollTime    = 1 * time.Second
 
 	testMoniker = "test-moniker"
 	testChainID = "chain-test"
@@ -92,30 +92,37 @@ func StartManager(t *testing.T, ctx context.Context, eotsHmacKey string, fpHmacK
 
 	var bc ccapi.ClientController
 	var bcc ccapi.ConsumerController
+
+	startTimeout := 30 * time.Second
+
 	require.Eventually(t, func() bool {
 		bbnCfg := fpcfg.BBNConfigToBabylonConfig(cfg.BabylonConfig)
 		bbnCl, err := bbnclient.New(&bbnCfg, logger)
 		if err != nil {
 			t.Logf("failed to create Babylon client: %v", err)
+			time.Sleep(100 * time.Millisecond)
 			return false
 		}
 		bc, err = bbncc.NewBabylonController(bbnCl, cfg.BabylonConfig, &cfg.BTCNetParams, logger)
 		if err != nil {
 			t.Logf("failed to create Babylon controller: %v", err)
+			time.Sleep(100 * time.Millisecond)
 			return false
 		}
 		err = bc.Start()
 		if err != nil {
 			t.Logf("failed to start Babylon controller: %v", err)
+			time.Sleep(200 * time.Millisecond)
 			return false
 		}
 		bcc, err = bbncc.NewBabylonConsumerController(cfg.BabylonConfig, &cfg.BTCNetParams, logger)
 		if err != nil {
 			t.Logf("failed to create Babylon consumer controller: %v", err)
+			time.Sleep(100 * time.Millisecond)
 			return false
 		}
 		return true
-	}, 5*time.Second, eventuallyPollTime)
+	}, startTimeout, eventuallyPollTime)
 
 	// Prepare EOTS manager
 	eotsHomeDir := filepath.Join(testDir, "eots-home")

--- a/itest/babylon/babylon_test_manager.go
+++ b/itest/babylon/babylon_test_manager.go
@@ -162,12 +162,6 @@ func StartManager(t *testing.T, ctx context.Context, eotsHmacKey string, fpHmacK
 	return tm
 }
 
-// generateDefaultHMACKey generates a consistent HMAC key for testing
-func generateDefaultHMACKey() (string, error) {
-	// Use a fixed key for testing to ensure consistency
-	return "TestHMACKey123456789012345678901234567890", nil
-}
-
 func (tm *TestManager) AddFinalityProvider(t *testing.T, ctx context.Context, hmacKey ...string) *service.FinalityProviderInstance {
 	r := rand.New(rand.NewSource(time.Now().Unix()))
 

--- a/itest/babylon/hmac_e2e_test.go
+++ b/itest/babylon/hmac_e2e_test.go
@@ -114,6 +114,15 @@ func TestHMACMismatch(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 
+	originalHmacKey := os.Getenv(client.HMACKeyEnvVar)
+	t.Cleanup(func() {
+		if originalHmacKey != "" {
+			os.Setenv(client.HMACKeyEnvVar, originalHmacKey)
+		} else {
+			os.Unsetenv(client.HMACKeyEnvVar)
+		}
+	})
+
 	// Generate two different HMAC keys
 	serverHmacKey, err := generateHMACKey()
 	require.NoError(t, err)

--- a/itest/babylon/hmac_e2e_test.go
+++ b/itest/babylon/hmac_e2e_test.go
@@ -5,17 +5,10 @@ package e2etest_babylon
 
 import (
 	"context"
-	cryptorand "crypto/rand"
-	"encoding/base64"
 	"testing"
 
-	bstypes "github.com/babylonlabs-io/babylon/x/btcstaking/types"
-	btcec "github.com/btcsuite/btcd/btcec/v2"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	"github.com/stretchr/testify/require"
-
-	"github.com/babylonlabs-io/finality-provider/finality-provider/service"
-	e2eutils "github.com/babylonlabs-io/finality-provider/itest"
 )
 
 // NewDescription creates a new validator description
@@ -27,70 +20,6 @@ func NewDescription(moniker string) *stakingtypes.Description {
 		SecurityContact: "",
 		Details:         "",
 	}
-}
-
-// generateHMACKey generates a random HMAC key for testing
-func generateHMACKey() (string, error) {
-	bytes := make([]byte, 32)
-	if _, err := cryptorand.Read(bytes); err != nil {
-		return "", err
-	}
-	return base64.StdEncoding.EncodeToString(bytes), nil
-}
-
-// startManagerWithHMAC starts a test manager with finality providers configured with HMAC
-func startManagerWithHMAC(t *testing.T, n int, ctx context.Context) (*TestManager, []*service.FinalityProviderInstance) {
-	defaultHmacKey := "TestHMACKey"
-
-	tm := StartManager(t, ctx, defaultHmacKey, defaultHmacKey)
-
-	var runningFps []*service.FinalityProviderInstance
-	for i := 0; i < n; i++ {
-		fpIns := tm.AddFinalityProvider(t, ctx, defaultHmacKey)
-		runningFps = append(runningFps, fpIns)
-	}
-
-	require.Eventually(t, func() bool {
-		fps, err := tm.BBNClient.QueryFinalityProviders()
-		if err != nil {
-			t.Logf("failed to query finality providers from Babylon %s", err.Error())
-			return false
-		}
-		return len(fps) == n
-	}, eventuallyWaitTimeOut, eventuallyPollTime)
-
-	return tm, runningFps
-}
-
-// TestHMACFinalityProviderLifeCycle tests the whole life cycle of a finality-provider with HMAC enabled
-func TestHMACFinalityProviderLifeCycle(t *testing.T) {
-	t.Parallel()
-	ctx := context.Background()
-	n := 2
-
-	tm, fps := startManagerWithHMAC(t, n, ctx)
-
-	tm.WaitForFpPubRandTimestamped(t, fps[0])
-
-	for _, fp := range fps {
-		_ = tm.InsertBTCDelegation(t, []*btcec.PublicKey{fp.GetBtcPk()}, e2eutils.StakingTime, e2eutils.StakingAmount)
-	}
-
-	delsResp := tm.WaitForNPendingDels(t, n)
-	var dels []*bstypes.BTCDelegation
-	for _, delResp := range delsResp {
-		del, err := e2eutils.ParseRespBTCDelToBTCDel(delResp)
-		require.NoError(t, err)
-		dels = append(dels, del)
-		tm.InsertCovenantSigForDelegation(t, del)
-	}
-
-	_ = tm.WaitForNActiveDels(t, n)
-
-	lastVotedHeight := tm.WaitForFpVoteCast(t, fps[0])
-
-	tm.CheckBlockFinalization(t, lastVotedHeight, 1)
-	t.Logf("the block at height %v is finalized using HMAC-authenticated finality provider", lastVotedHeight)
 }
 
 // TestHMACMismatch tests that using mismatched HMAC keys between EOTS server and client

--- a/itest/babylon/hmac_e2e_test.go
+++ b/itest/babylon/hmac_e2e_test.go
@@ -39,15 +39,10 @@ func generateHMACKey() (string, error) {
 }
 
 // startManagerWithHMAC starts a test manager with finality providers configured with HMAC
-func startManagerWithHMAC(t *testing.T, n int, ctx context.Context) (*TestManager, []*service.FinalityProviderInstance, func()) {
-	defaultHmacKey, err := generateDefaultHMACKey()
-	require.NoError(t, err)
+func startManagerWithHMAC(t *testing.T, n int, ctx context.Context) (*TestManager, []*service.FinalityProviderInstance) {
+	defaultHmacKey := "TestHMACKey"
 
 	tm := StartManager(t, ctx, defaultHmacKey, defaultHmacKey)
-
-	cleanup := func() {
-		tm.Stop(t)
-	}
 
 	var runningFps []*service.FinalityProviderInstance
 	for i := 0; i < n; i++ {
@@ -64,7 +59,7 @@ func startManagerWithHMAC(t *testing.T, n int, ctx context.Context) (*TestManage
 		return len(fps) == n
 	}, eventuallyWaitTimeOut, eventuallyPollTime)
 
-	return tm, runningFps, cleanup
+	return tm, runningFps
 }
 
 // TestHMACFinalityProviderLifeCycle tests the whole life cycle of a finality-provider with HMAC enabled
@@ -73,8 +68,7 @@ func TestHMACFinalityProviderLifeCycle(t *testing.T) {
 	ctx := context.Background()
 	n := 2
 
-	tm, fps, cleanup := startManagerWithHMAC(t, n, ctx)
-	defer cleanup()
+	tm, fps := startManagerWithHMAC(t, n, ctx)
 
 	tm.WaitForFpPubRandTimestamped(t, fps[0])
 

--- a/itest/babylon/hmac_e2e_test.go
+++ b/itest/babylon/hmac_e2e_test.go
@@ -143,7 +143,7 @@ func TestHMACMismatch(t *testing.T) {
 	msgToSign := []byte("test message for signing")
 	_, err = altClient.SignSchnorrSig([]byte(eotsKeyName), msgToSign)
 	require.Error(t, err, "SignSchnorrSig should fail with mismatched HMAC keys")
-	require.Contains(t, err.Error(), "invalid HMAC signature", "Expected HMAC authentication error during SignSchnorrSig")
+	require.Contains(t, err.Error(), "invalid HMAC", "Expected HMAC authentication error during SignSchnorrSig")
 
 	// Switch back to the correct HMAC key to verify the operation works properly
 	os.Setenv(client.HMACKeyEnvVar, serverHmacKey)
@@ -152,7 +152,7 @@ func TestHMACMismatch(t *testing.T) {
 	defer correctClient.Close()
 
 	_, err = correctClient.SignSchnorrSig([]byte(eotsKeyName), msgToSign)
-	require.NotContains(t, err.Error(), "invalid HMAC signature", "Should not get HMAC authentication error with correct key")
+	require.NotContains(t, err.Error(), "invalid HMAC", "Should not get HMAC authentication error with correct key")
 
 	t.Logf("Successfully verified HMAC authentication: operations fail with wrong key but work with correct key")
 }

--- a/itest/cosmwasm/bcd/bcd_test_manager.go
+++ b/itest/cosmwasm/bcd/bcd_test_manager.go
@@ -163,7 +163,7 @@ func StartBcdTestManager(t *testing.T, ctx context.Context) *BcdTestManager {
 	eh := e2eutils.NewEOTSServerHandler(t, eotsCfg, eotsHomeDir)
 	eh.Start(ctx)
 	cfg.RPCListener = fmt.Sprintf("127.0.0.1:%d", testutil.AllocateUniquePort(t))
-	eotsCli, err := client.NewEOTSManagerGRpcClient(eotsCfg.RPCListener)
+	eotsCli, err := client.NewEOTSManagerGRpcClient(eotsCfg.RPCListener, "")
 	require.NoError(t, err)
 
 	// 5. prepare finality-provider

--- a/itest/eotsmanager_handler.go
+++ b/itest/eotsmanager_handler.go
@@ -2,7 +2,6 @@ package e2e_utils
 
 import (
 	"context"
-	"os"
 	"testing"
 
 	"github.com/btcsuite/btcd/btcec/v2"
@@ -11,7 +10,6 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/babylonlabs-io/finality-provider/eotsmanager"
-	"github.com/babylonlabs-io/finality-provider/eotsmanager/client"
 	"github.com/babylonlabs-io/finality-provider/eotsmanager/config"
 	"github.com/babylonlabs-io/finality-provider/eotsmanager/service"
 )
@@ -71,13 +69,8 @@ func (eh *EOTSServerHandler) GetFPPrivKey(t *testing.T, fpPk []byte) *btcec.Priv
 	return privKey.PrivKey
 }
 
-// SetHMACKey sets the HMAC key in the environment for the EOTS server
+// SetHMACKey sets the HMAC key in the config for the EOTS server
 func (eh *EOTSServerHandler) SetHMACKey(hmacKey string) error {
-	if err := os.Setenv(client.HMACKeyEnvVar, hmacKey); err != nil {
-		return err
-	}
-
 	eh.cfg.HMACKey = hmacKey
-
 	return nil
 }

--- a/itest/test-manager/base_test_manager.go
+++ b/itest/test-manager/base_test_manager.go
@@ -579,7 +579,7 @@ func StartEotsManagers(
 		var eotsCli *eotsclient.EOTSManagerGRpcClient
 		var err error
 		require.Eventually(t, func() bool {
-			eotsCli, err = eotsclient.NewEOTSManagerGRpcClient(fpCfgs[i].EOTSManagerAddress)
+			eotsCli, err = eotsclient.NewEOTSManagerGRpcClient(fpCfgs[i].EOTSManagerAddress, fpCfgs[i].HMACKey)
 			if err != nil {
 				t.Logf("Error creating EOTS client: %v", err)
 


### PR DESCRIPTION
Check full proto names of the excluded from hmac methods instead of with suffix. Removes the requirement for ENV variable setting and only keeps config settings.