### PR TITLE
[backport]chore: enforcing keyring-backend test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ changes in messages and state
 ### Bug Fixes
 
 * [#368](https://github.com/babylonlabs-io/finality-provider/pull/368) fix: fpd config validate
+* [#382](https://github.com/babylonlabs-io/finality-provider/pull/382) chore: enforcing keyring-backend test in `fpd start` and `eotsd start`
 
 ## v1.0.0-rc.2
 

--- a/eotsmanager/cmd/eotsd/daemon/start.go
+++ b/eotsmanager/cmd/eotsd/daemon/start.go
@@ -38,6 +38,10 @@ func startFn(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("failed to load config at %s: %w", homePath, err)
 	}
 
+	if cfg.KeyringBackend != "test" {
+		return fmt.Errorf("the keyring backend in config must be `test` for automatic signing, got %s", cfg.KeyringBackend)
+	}
+
 	rpcListener, err := cmd.Flags().GetString(rpcListenerFlag)
 	if err != nil {
 		return fmt.Errorf("failed to get RPC listener flag: %w", err)

--- a/finality-provider/cmd/fpd/daemon/flags.go
+++ b/finality-provider/cmd/fpd/daemon/flags.go
@@ -13,11 +13,11 @@ const (
 	upToHeight           = "up-to-height"
 
 	// flags for description
-	monikerFlag                 = "moniker"
-	identityFlag                = "identity"
-	websiteFlag                 = "website"
-	securityContactFlag         = "security-contact"
-	detailsFlag                 = "details"
+	monikerFlag         = "moniker"
+	identityFlag        = "identity"
+	websiteFlag         = "website"
+	securityContactFlag = "security-contact"
+	detailsFlag         = "details"
 
 	// flags for commission
 	commissionRateFlag          = "commission-rate"

--- a/finality-provider/cmd/fpd/daemon/start.go
+++ b/finality-provider/cmd/fpd/daemon/start.go
@@ -59,6 +59,10 @@ func runStartCmd(ctx client.Context, cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("failed to load configuration: %w", err)
 	}
 
+	if cfg.BabylonConfig.KeyringBackend != "test" {
+		return fmt.Errorf("the keyring backend in config must be `test` for automatic signing, got %s", cfg.BabylonConfig.KeyringBackend)
+	}
+
 	if rpcListener != "" {
 		_, err := net.ResolveTCPAddr("tcp", rpcListener)
 		if err != nil {


### PR DESCRIPTION
closes: https://github.com/babylonlabs-io/finality-provider/issues/338

Due to the need of continuous signing from the FP's we need to enforce keyring-backend test over file and os. This was seen as problematic for users during the testnet