### PR TITLE
chore: Modify default config and add validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * [#399](https://github.com/babylonlabs-io/finality-provider/pull/399) chore: submit immediately
 * [#410](https://github.com/babylonlabs-io/finality-provider/pull/410) chore: rollback sign records from eots store
 * [#413](https://github.com/babylonlabs-io/finality-provider/pull/413) chore: rm default value for app hash flag
+* [#417](https://github.com/babylonlabs-io/finality-provider/pull/417) chore: Modify default config and add validation
 
 ## v1.0.0-rc.2
 

--- a/finality-provider/config/config.go
+++ b/finality-provider/config/config.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"fmt"
-	"net"
 	"path/filepath"
 	"strconv"
 	"time"
@@ -17,6 +16,7 @@ import (
 	"github.com/babylonlabs-io/finality-provider/util"
 )
 
+// Constants for config default values
 const (
 	defaultChainType                   = "babylon"
 	defaultLogLevel                    = zapcore.DebugLevel
@@ -26,15 +26,21 @@ const (
 	DefaultRPCPort                     = 12581
 	defaultConfigFileName              = "fpd.conf"
 	defaultNumPubRand                  = 50000 // support running of roughly 5 days with block production time as 10s
-	defaultNumPubRandMax               = 500000
-	defaultTimestampingDelayBlocks     = 6000 // 100 BTC blocks * 600s / 10s
-	defaultBatchSubmissionSize         = 1000
-	defaultRandomInterval              = 30 * time.Second
+	defaultBatchSubmissionSize         = 100
 	defaultSubmitRetryInterval         = 1 * time.Second
 	defaultSignatureSubmissionInterval = 1 * time.Second
 	defaultMaxSubmissionRetries        = 20
 	defaultBitcoinNetwork              = "signet"
 	defaultDataDirname                 = "data"
+)
+
+// Constants for system parameters validation limits
+const (
+	MaxBatchSize            = 100              // Maximum allowed batch submission size
+	MaxPubRand              = 500000           // Maximum allowed public randomness number
+	MinPubRand              = 8192             // Minimum allowed public randomness number
+	TimestampingDelayBlocks = 18000            // 300 BTC blocks * 600s / 10s where 300 BTC blocks is the system parameter of BTC block time required by the btc timestamping protocol
+	RandCommitInterval      = 30 * time.Second // Interval between check of randomness commit
 )
 
 var (
@@ -54,13 +60,10 @@ type Config struct {
 	LogLevel                    string        `long:"loglevel" description:"Logging level for all subsystems" choice:"trace" choice:"debug" choice:"info" choice:"warn" choice:"error" choice:"fatal"`
 	ChainType                   string        `long:"chaintype" description:"the type of the consumer chain" choice:"babylon" choice:"OPStackL2" choice:"wasm"`
 	NumPubRand                  uint32        `long:"numPubRand" description:"The number of Schnorr public randomness for each commitment"`
-	NumPubRandMax               uint32        `long:"numpubrandmax" description:"The upper bound of the number of Schnorr public randomness for each commitment"`
-	TimestampingDelayBlocks     uint32        `long:"timestampingdelayblocks" description:"The delay, measured in blocks, between a randomness commit submission and the randomness is BTC-timestamped"`
 	MaxSubmissionRetries        uint32        `long:"maxsubmissionretries" description:"The maximum number of retries to submit finality signature or public randomness"`
 	EOTSManagerAddress          string        `long:"eotsmanageraddress" description:"The address of the remote EOTS manager; Empty if the EOTS manager is running locally"`
 	HMACKey                     string        `long:"hmackey" description:"The HMAC key for authentication with EOTSD. If not provided, will use HMAC_KEY environment variable."`
 	BatchSubmissionSize         uint32        `long:"batchsubmissionsize" description:"The size of a batch in one submission"`
-	RandomnessCommitInterval    time.Duration `long:"randomnesscommitinterval" description:"The interval between each attempt to commit public randomness"`
 	SubmissionRetryInterval     time.Duration `long:"submissionretryinterval" description:"The interval between each attempt to submit finality signature or public randomness after a failure"`
 	SignatureSubmissionInterval time.Duration `long:"signaturesubmissioninterval" description:"The interval between each finality signature(s) submission"`
 
@@ -95,10 +98,7 @@ func DefaultConfigWithHome(homePath string) Config {
 		BabylonConfig:               &bbnCfg,
 		PollerConfig:                &pollerCfg,
 		NumPubRand:                  defaultNumPubRand,
-		NumPubRandMax:               defaultNumPubRandMax,
-		TimestampingDelayBlocks:     defaultTimestampingDelayBlocks,
 		BatchSubmissionSize:         defaultBatchSubmissionSize,
-		RandomnessCommitInterval:    defaultRandomInterval,
 		SubmissionRetryInterval:     defaultSubmitRetryInterval,
 		SignatureSubmissionInterval: defaultSignatureSubmissionInterval,
 		MaxSubmissionRetries:        defaultMaxSubmissionRetries,
@@ -173,36 +173,83 @@ func LoadConfig(homePath string) (*Config, error) {
 // illegal values or a combination of values are set. All file system paths are
 // normalized. The cleaned up config is returned on success.
 func (cfg *Config) Validate() error {
-	if cfg.EOTSManagerAddress == "" {
-		return fmt.Errorf("EOTS manager address not specified")
-	}
-	// Multiple networks can't be selected simultaneously.  Count number of
-	// network flags passed; assign active network params
-	// while we're at it.
-	btcNetConfig, err := NetParamsBTC(cfg.BitcoinNetwork)
-	if err != nil {
-		return err
-	}
-	cfg.BTCNetParams = btcNetConfig
-
-	_, err = net.ResolveTCPAddr("tcp", cfg.RPCListener)
-	if err != nil {
-		return fmt.Errorf("invalid RPC listener address %s, %w", cfg.RPCListener, err)
+	if cfg == nil {
+		return fmt.Errorf("config cannot be nil")
 	}
 
-	if cfg.Metrics == nil {
-		return fmt.Errorf("empty metrics config")
+	// Validate timing configurations
+	if err := cfg.validateTimingConfigs(); err != nil {
+		return fmt.Errorf("timing configuration validation failed: %w", err)
 	}
 
-	if err := cfg.Metrics.Validate(); err != nil {
-		return fmt.Errorf("invalid metrics config: %w", err)
+	// Validate batch and retry configurations
+	if err := cfg.validateBatchAndRetryConfigs(); err != nil {
+		return fmt.Errorf("batch and retry configuration validation failed: %w", err)
+	}
+
+	// Validate poller configuration
+	if cfg.PollerConfig == nil {
+		return fmt.Errorf("poller config cannot be empty")
 	}
 
 	if err := cfg.PollerConfig.Validate(); err != nil {
-		return fmt.Errorf("invalid poller config: %w", err)
+		return fmt.Errorf("poller configuration validation failed: %w", err)
 	}
 
-	// All good, return the sanitized result.
+	// Validate metrics configuration
+	if cfg.Metrics == nil {
+		return fmt.Errorf("metrics configuration cannot be empty")
+	}
+	if err := cfg.Metrics.Validate(); err != nil {
+		return fmt.Errorf("metrics configuration validation failed: %w", err)
+	}
+
+	btcNetParams, err := NetParamsBTC(cfg.BitcoinNetwork)
+	if err != nil {
+		return fmt.Errorf("invalid BTC network: %w", err)
+	}
+
+	cfg.BTCNetParams = btcNetParams
+
+	return nil
+}
+
+func (cfg *Config) validateTimingConfigs() error {
+	// Validate SignatureSubmissionInterval
+	if cfg.SignatureSubmissionInterval <= 0 {
+		return fmt.Errorf("signature submission interval must be positive, got %v", cfg.SignatureSubmissionInterval)
+	}
+
+	// Validate SubmissionRetryInterval
+	if cfg.SubmissionRetryInterval <= 0 {
+		return fmt.Errorf("submission retry interval must be positive, got %v", cfg.SubmissionRetryInterval)
+	}
+
+	return nil
+}
+
+func (cfg *Config) validateBatchAndRetryConfigs() error {
+	// Validate BatchSubmissionSize
+	if cfg.BatchSubmissionSize <= 0 {
+		return fmt.Errorf("batch submission size must be positive, got %d", cfg.BatchSubmissionSize)
+	}
+	if cfg.BatchSubmissionSize > MaxBatchSize {
+		return fmt.Errorf("batch submission size must not exceed %d, got %d", MaxBatchSize, cfg.BatchSubmissionSize)
+	}
+
+	// Validate MaxSubmissionRetries
+	if cfg.MaxSubmissionRetries <= 0 {
+		return fmt.Errorf("max submission retries must be positive, got %d", cfg.MaxSubmissionRetries)
+	}
+
+	// Validate NumPubRand
+	if cfg.NumPubRand < MinPubRand {
+		return fmt.Errorf("number of public randomness must not be less than %d, got %d", MinPubRand, cfg.NumPubRand)
+	}
+	if cfg.NumPubRand > MaxPubRand {
+		return fmt.Errorf("number of public randomness must not exceed %d, got %d", MaxPubRand, cfg.NumPubRand)
+	}
+
 	return nil
 }
 

--- a/finality-provider/config/config_test.go
+++ b/finality-provider/config/config_test.go
@@ -1,0 +1,143 @@
+package config_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/babylonlabs-io/finality-provider/finality-provider/config"
+)
+
+var fpCfg = config.DefaultConfig()
+
+func TestConfig_Validate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		cfg     *config.Config
+		wantErr string
+	}{
+		{
+			name:    "valid config",
+			cfg:     &fpCfg,
+			wantErr: "",
+		},
+		{
+			name:    "nil config",
+			cfg:     nil,
+			wantErr: "config cannot be nil",
+		},
+		{
+			name: "zero signature submission interval",
+			cfg: &config.Config{
+				SignatureSubmissionInterval: 0,
+				SubmissionRetryInterval:     time.Second,
+				BatchSubmissionSize:         100,
+				MaxSubmissionRetries:        50,
+				NumPubRand:                  100,
+				PollerConfig:                defaultPollerConfig(),
+			},
+			wantErr: "timing configuration validation failed: signature submission interval must be positive, got 0s",
+		},
+		{
+			name: "zero submission retry interval",
+			cfg: &config.Config{
+				SignatureSubmissionInterval: time.Second,
+				SubmissionRetryInterval:     0,
+				BatchSubmissionSize:         100,
+				MaxSubmissionRetries:        50,
+				NumPubRand:                  100,
+				PollerConfig:                defaultPollerConfig(),
+			},
+			wantErr: "timing configuration validation failed: submission retry interval must be positive, got 0s",
+		},
+		{
+			name: "zero batch submission size",
+			cfg: &config.Config{
+				SignatureSubmissionInterval: time.Second,
+				SubmissionRetryInterval:     time.Second,
+				BatchSubmissionSize:         0,
+				MaxSubmissionRetries:        50,
+				NumPubRand:                  100,
+				PollerConfig:                defaultPollerConfig(),
+			},
+			wantErr: "batch and retry configuration validation failed: batch submission size must be positive, got 0",
+		},
+		{
+			name: "batch submission size exceeds maximum",
+			cfg: &config.Config{
+				SignatureSubmissionInterval: time.Second,
+				SubmissionRetryInterval:     time.Second,
+				BatchSubmissionSize:         config.MaxBatchSize + 1,
+				MaxSubmissionRetries:        50,
+				NumPubRand:                  100,
+				PollerConfig:                defaultPollerConfig(),
+			},
+			wantErr: "batch and retry configuration validation failed: batch submission size must not exceed 100, got 101",
+		},
+		{
+			name: "zero max submission retries",
+			cfg: &config.Config{
+				SignatureSubmissionInterval: time.Second,
+				SubmissionRetryInterval:     time.Second,
+				BatchSubmissionSize:         100,
+				MaxSubmissionRetries:        0,
+				NumPubRand:                  100,
+				PollerConfig:                defaultPollerConfig(),
+			},
+			wantErr: "batch and retry configuration validation failed: max submission retries must be positive, got 0",
+		},
+		{
+			name: "num pub rand exceeds maximum",
+			cfg: &config.Config{
+				SignatureSubmissionInterval: time.Second,
+				SubmissionRetryInterval:     time.Second,
+				BatchSubmissionSize:         100,
+				MaxSubmissionRetries:        50,
+				NumPubRand:                  config.MaxPubRand + 1,
+				PollerConfig:                defaultPollerConfig(),
+			},
+			wantErr: "batch and retry configuration validation failed: number of public randomness must not exceed 500000, got 500001",
+		},
+		{
+			name: "nil poller config",
+			cfg: &config.Config{
+				SignatureSubmissionInterval: time.Second,
+				SubmissionRetryInterval:     time.Second,
+				BatchSubmissionSize:         100,
+				MaxSubmissionRetries:        50,
+				NumPubRand:                  config.MinPubRand,
+				PollerConfig:                nil,
+			},
+			wantErr: "poller config cannot be empty",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := tt.cfg.Validate()
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+// Helper function to create a default valid ChainPollerConfig for testing
+func defaultPollerConfig() *config.ChainPollerConfig {
+	return &config.ChainPollerConfig{
+		BufferSize:                     1000,
+		PollInterval:                   time.Second,
+		StaticChainScanningStartHeight: 1,
+		AutoChainScanningMode:          true,
+		PollSize:                       1000,
+	}
+}

--- a/finality-provider/service/benchmark_helper.go
+++ b/finality-provider/service/benchmark_helper.go
@@ -6,6 +6,7 @@ import (
 
 	"go.uber.org/zap"
 
+	"github.com/babylonlabs-io/finality-provider/finality-provider/config"
 	"github.com/babylonlabs-io/finality-provider/types"
 )
 
@@ -28,7 +29,7 @@ func (fp *FinalityProviderInstance) HelperCommitPubRand(tipHeight uint64) (*type
 	case lastCommittedHeight == uint64(0):
 		// the finality-provider has never submitted public rand before
 		startHeight = tipHeight + 1
-	case lastCommittedHeight < uint64(fp.cfg.TimestampingDelayBlocks)+tipHeight:
+	case lastCommittedHeight < uint64(config.TimestampingDelayBlocks)+tipHeight:
 		// (should not use subtraction because they are in the type of uint64)
 		// we are running out of the randomness
 		startHeight = lastCommittedHeight + 1

--- a/finality-provider/service/fp_instance.go
+++ b/finality-provider/service/fp_instance.go
@@ -348,7 +348,7 @@ func (fp *FinalityProviderInstance) randomnessCommitmentLoop() {
 
 	fp.processRandomnessCommitment()
 
-	ticker := time.NewTicker(fp.cfg.RandomnessCommitInterval)
+	ticker := time.NewTicker(fpcfg.RandCommitInterval)
 	defer ticker.Stop()
 
 	for {
@@ -412,7 +412,7 @@ func (fp *FinalityProviderInstance) ShouldCommitRandomness() (bool, uint64, erro
 		return false, 0, fmt.Errorf("failed to get the last block: %w", err)
 	}
 
-	tipHeightWithDelay := tipHeight + uint64(fp.cfg.TimestampingDelayBlocks)
+	tipHeightWithDelay := tipHeight + uint64(fpcfg.TimestampingDelayBlocks)
 
 	var startHeight uint64
 	switch {

--- a/itest/utils.go
+++ b/itest/utils.go
@@ -104,9 +104,6 @@ func DefaultFpConfig(keyringDir, homeDir string) *config.Config {
 	cfg := config.DefaultConfigWithHome(homeDir)
 
 	cfg.NumPubRand = 1000
-	cfg.NumPubRandMax = 1000
-	cfg.TimestampingDelayBlocks = 0
-
 	cfg.BitcoinNetwork = "simnet"
 	cfg.BTCNetParams = chaincfg.SimNetParams
 


### PR DESCRIPTION
The point of this PR is to ensure that users cannot insert config values that will cause the fp to crash or jailed. Notable changes are:
- Remove config items `NumPubRandMax`, `TimestampingDelayBlocks`, `RandomnessCommitInterval` but hardcode them as they are critical ones that should not be changeable. `TimestampingDelayBlocks` is calculated based on `w=300` and babylon block production time of `10s`
- Add validations to config items. Note that `MinPubRand` to ensure that a commit can pass verification on Babylon side.

@babylonlabs-io/integration-dev Not sure this will have impact on the integration side. Please review