### PR TITLE
chore: Modify default config and add validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ changes in messages and state
 * [#397](https://github.com/babylonlabs-io/finality-provider/pull/397) chore: overwrite randomness proof
 * [#399](https://github.com/babylonlabs-io/finality-provider/pull/399) chore: submit immediately
 * [#410](https://github.com/babylonlabs-io/finality-provider/pull/410) chore: rollback sign records from eots store
+* [#417](https://github.com/babylonlabs-io/finality-provider/pull/417) chore: Modify default config and add validation
 
 ## v1.0.0-rc.2
 

--- a/docs/commit-pub-rand.md
+++ b/docs/commit-pub-rand.md
@@ -4,16 +4,16 @@
 
 The finality provider periodically commits public randomness to the consumer
 chain to be used for future block finalization. This document specifies the
-process of committing public randomness.
+process for committing public randomness.
 
 ## Commit Process
 
 ### Generating a Commit
 
 A randomness pair is essentially a pair of `32-byte` points over `secp256k1`.
-A public randomness commit is a list of public
-randomness, each committed to a specific height. In particular, a commit
-consists of:
+A public randomness commit is a commitment to an association
+between public randomnesses and heights for them to be used.
+In particular, a commit consists of:
 
 - a merkle root containing a list of public randomness values,
 - a start height, indicating from which height the randomness starts, and
@@ -22,38 +22,51 @@ consists of:
 To generate a new commit, following steps are needed:
 
 1. Generate a list of randomness. This requires an RPC call to the EOTS manager
-  (eotsd) to generate a list of public randomness, each corresponding to a
-  specific height according to the start height and the number of randomness in
-  the request. Randomness generation is required to be deterministic.
-2. Construct the merkle tree based on the list of randomness using the CometBFT's [merkle](https://github.com/cometbft/cometbft/tree/main/crypto/merkle)
-  library. The merkle root will be used in the commit, while each randomness
-  number and their merkle proofs will be used for finality vote submission
-  in the future.
-3. Send a [Schnorr](https://github.com/btcsuite/btcd/blob/684d64ad74fed203fb846c032f2b55b3e3c36734/btcec/schnorr/signature.go#L391)
-  signature request to the EOTS manager over the hash of the commit
-  (concatenated by the start height, number of randomness, and the merkle root).
-4. Build the commit message ([MsgCommitPubRandList](https://github.com/babylonlabs-io/babylon/blob/aa99e2eb093e06cb9a28a58f373e8fa5f2494383/proto/babylon/finality/v1/tx.proto#L29))
-  and send a transaction to Babylon.
+   daemon (`eotsd`) to generate a list of public randomness,
+   each corresponding to a specific height according to the start height and
+   the number of randomness in the request.
+   Randomness generation is required to be deterministic.
+2. Construct the merkle tree based on the list of randomness using the CometBFT's
+   [merkle](https://github.com/cometbft/cometbft/tree/main/crypto/merkle)
+   library. The merkle root will be used in the commit, while each randomness
+   number and their merkle proofs will be used for finality vote submission
+   in the future.
+3. Send a
+   [Schnorr](https://github.com/btcsuite/btcd/blob/684d64ad74fed203fb846c032f2b55b3e3c36734/btcec/schnorr/signature.go#L391)
+   signature request to the EOTS manager over the hash of the commit
+   (concatenated by the start height, number of randomness, and the merkle root).
+4. Build the commit message
+   ([MsgCommitPubRandList](https://github.com/babylonlabs-io/babylon/blob/aa99e2eb093e06cb9a28a58f373e8fa5f2494383/proto/babylon/finality/v1/tx.proto#L29))
+   and send a transaction to Babylon.
 
 ### Timing to Commit
 
-Public randomness is an essential component of finality. It should be
-committed before finality votes can be sent. Otherwise, the finality provider
-looses voting power for this height.
+Public randomness is an essential component of finality voting. It should be
+committed before finality votes can be sent.
+If the finality provider does not have public randomness committed for a
+specific height, they can't vote for it and therefore lose the voting power
+they would have otherwise had for it.
 
 To this end, when a finality provider is started, it runs a loop to periodically
-check whether it needs to make a new commit and calculate the start height of
-the next commit. In particular:
+check whether it needs to make a new commit and calculate the height
+its next public randomness commit should start with. In particular:
 
 ```go
+    // Estimate the consumer chain block height
+    // a new commitment of public randomness would be Bitcoin timestamped
+    // and ready for use, if the commitment was made in the current
+    // consumer chain block.
 	tipHeightWithDelay := tipHeight + uint64(fp.cfg.TimestampingDelayBlocks)
 	var startHeight uint64
 	switch {
 	case lastCommittedHeight < tipHeightWithDelay:
-		// the start height should consider the timestamping delay
-		// as it is only available to use after tip height + estimated timestamping delay
+        // If the last height the finality provider has committed
+        // randomness, is less than the estimation, then
+        // the finality provider should commit randomness from that height.
 		startHeight = tipHeightWithDelay
 	case lastCommittedHeight < tipHeightWithDelay+uint64(fp.cfg.NumPubRand):
+        // otherwise, the finality provider should commit randomness
+        // from the last height it has committed to
 		startHeight = lastCommittedHeight + 1
 	default:
         // randomness is sufficient, do not need to make a commit
@@ -62,18 +75,19 @@ the next commit. In particular:
 where:
 
 - `lastCommittedHeight` is the end height (`startHeight + numRand - 1`)
-from the latest public randomness commit recorded on the consumer chain
+  of the latest public randomness commit recorded on the consumer chain
 - `tipHeight` is the current height of the consumer chain
 - `TimestampingDelayBlocks` is a configuration value, which measures when to make a
   new commit
 - `NumPubRand` is the number of randomness in a commit defined in the config.
 
-### Determining TimestampingDelayBlocks
+### Determining `TimestampingDelayBlocks`
 
-The value of `TimestampingDelayBlocks` must account for BTC-timestamping
-delays, which is needed to activate the randomness for a specific height
-after the committed epoch is BTC-timestamped. Here's an example:
+The configuration value `TimestampingDelayBlocks` defines an estimation
+estimation of the number of consumer chain blocks that will be generated
+until a public randomness commit is Bitcoin timestamped.
 
+Here's an example:
 - The consumer chain receives a commit with:
   - Start height: 100
   - Number of randomness values: 1000
@@ -83,45 +97,43 @@ after the committed epoch is BTC-timestamped. Here's an example:
 
 The BTC-timestamping protocol requires:
 
-- 100 BTC blocks for epoch finalization
-- ≈ 1000 minutes (17 hours) at 10-minute average block time
-- With consumer chain blocks every 10 seconds, this equals approximately 6,000
+- 300 BTC blocks for epoch finalization
+- ≈ 3000 minutes (50 hours) at 10-minute average block time
+- With consumer chain blocks every 10 seconds, this equals approximately 18,000
   blocks
 
 Therefore,
 
-- `TimestampingDelayBlocks` should be around 6,000
-- Recommended production value: > 10,000 to provide additional safety margin
+- `TimestampingDelayBlocks` should be around 18,000
+- Recommended production value: > 20,000 to provide additional safety margin
 
-### Determining Start Height
+### Determining the Start Height for a Commit
 
-To determine the start height of a commit:
+To determine the start height for a commit:
 
-1. For first-time commit:
-   - `startHeight = baseHeight + 1`,
-   - where `baseHeight` is a future height which is estimated based on the
-     BTC-timestamping delays.
-2. For subsequent commit:
+1. If this is a first time commit or the finality provider has not committed
+   for a long time:
+   - `startHeight = currentConsumerChainHeight + TimestampingDelayBlocks + 1`
+2. For subsequent commits:
    - `startHeight = lastCommittedHeight + 1`,
    - where `lastCommittedHeight` is obtained from the consumer chain.
 
 The `baseHeight` can be specified via configuration or CLI options.
 
-**Important Notes:**
-
-- After long downtime, treat as first-time commit by specifying `baseHeight`.
-- Consecutiveness across commits is not enforced by the system but
-  different commits must not overlap.
-- `startHeight` should not be higher than `finalityActivationHeight`,
-a parameter defined in Babylon. Therefore,
-`startHeight = max(startHeight, finalityActivationHeight)`.
+> **Important Notes:**
+> - Consecutiveness across commits is not enforced by the system but
+>   different commits must not overlap.
+> - `startHeight` should not be higher than `finalityActivationHeight`,
+>    a parameter defined in Babylon Genesis specifying when the finality
+>    protocol is activated.
+>    Therefore, `startHeight = max(startHeight, finalityActivationHeight)`.
 
 ### Determining the Number of Randomness
 
-The number of randomness contained in a commit is specified in the config
-`NumPubRand`. A general strategy is that the value should be as large
-as possible. This is because each commit to the consumer chain costs gas.
-  
+The number of randomness contained in a commit is specified in the `NumPubRand`
+configuration. A general strategy is that the value should be as large
+as possible. This is because each commit of the consumer chain costs gas.
+
 However, in real life, this stategy might not always gain due to the following
 reasons:
 
@@ -135,5 +147,11 @@ Additionally, given that the end height of a commit equals to
 `startHeight + NumPubRand - 1`, we should ensure that the condition
 `lastCommittedHeight > tipHeight + uint64(TimestampingDelayBlocks)` can hold for
 a long period of time to avoid frequent commit of randomness.
-In real life, the value of `NumPubRand` should be much larger than
-`TimestampingDelayBlocks`, e.g., `NumPubRand = 2 * TimestampingDelayBlocks`.
+
+> **Important Note**:
+> In real life, the value of `NumPubRand` should be much larger than
+> `TimestampingDelayBlocks`, e.g., `NumPubRand = 2 * TimestampingDelayBlocks`.
+
+> **Important Note**:
+> The finality provider daemon enforces a minimum
+> of `16384` of `NumPubRand` and a maximum of `50000`.

--- a/finality-provider/config/config.go
+++ b/finality-provider/config/config.go
@@ -32,29 +32,36 @@ const (
 	defaultMaxSubmissionRetries        = 20
 	defaultBitcoinNetwork              = "signet"
 	defaultDataDirname                 = "data"
-	// TimestampingDelayBlocks is the delay for a commit to become available due to BTC timestamping protocol
-	// it is calculated by converting BTC block time (parameter w=300) to Babylon Genesis block time
-	// 300 BTC blocks * 600s / 10s where 300 BTC blocks is the system parameter of BTC block time required
-	// by the btc timestamping protocol.
-	// for testnet with w=100, the recommended default value is 6000
+	// TimestampingDelayBlocks is an estimation on the delay
+	// for a commit to become available due to BTC timestamping protocol,
+	// counted as the number of Babylon Genesis' blocks.
+	// It is calculated by converting the time it takes for the public randomness
+	// to be BTC timestamped counted as Bitcoin blocks to Babylon Genesis blocks.
+	// As this is an estimation, we make the following assumptions:
+	//    - Babylon Genesis' block time: 10s
+	//    - Bitcoin's block time: 10m => 60 Babylon Genesis blocks per Bitcoin block.
+	//    - Babylon Genesis' finalization delta: 300 blocks
+	// The above leads to a recommended default value of 300 * 60 = 18000 Babylon blocks.
+	// You should set this parameter depending on the network you connect to.
 	defaultTimestampingDelayBlocks = 18000
 )
 
 // Constants for system parameters validation limits
 const (
-	// MaxBatchSize is the maximum allowed batch submission size,
-	// this limits BatchSubmissionSize as larger values could cause error due to insufficient fees
+	// MaxBatchSize is the maximum allowed batch submission size
+	// This constant limits BatchSubmissionSize as larger values could cause an error due to insufficient fees.
 	MaxBatchSize = 100
-	// MaxPubRand is the maximum allowed number of public randomness in each commit,
-	// this limits NumPubRand as larger values could take more than 10min to generate/store
-	// rand proofs
+	// MaxPubRand is the maximum allowed number of public randomness in each public randomness commit.
+	// This constant limits NumPubRand as larger values could take more than 10min to generate/store
+	// the randomness proofs.
 	MaxPubRand = 500000 //
-	// MinPubRand is the minimum allowed number of public randomness in each commit
-	// a commit with less than this value will be rejected by Babylon Genesis
-	MinPubRand = 8192
+	// MinPubRand is the minimum allowed number of public randomness in each public randomness commit.
+	// This constant limits NumPubRand to be generally large to cover inaccurate estimation of BTC block time.
+	// For example, Bitcoin is running slow and by the time when the commit is timestamped, the randomness is run out.
+	MinPubRand = 18000
 	// RandCommitInterval is the interval between each check of whether a new commit needs to be made,
 	// technically this could be a large value depending on NumPubRand, but hardcode a small value for safety
-	RandCommitInterval = 30 * time.Second // Interval between check of randomness commit
+	RandCommitInterval = 30 * time.Second
 )
 
 var (

--- a/finality-provider/config/config.go
+++ b/finality-provider/config/config.go
@@ -36,11 +36,25 @@ const (
 
 // Constants for system parameters validation limits
 const (
-	MaxBatchSize            = 100              // Maximum allowed batch submission size
-	MaxPubRand              = 500000           // Maximum allowed public randomness number
-	MinPubRand              = 8192             // Minimum allowed public randomness number
-	TimestampingDelayBlocks = 18000            // 300 BTC blocks * 600s / 10s where 300 BTC blocks is the system parameter of BTC block time required by the btc timestamping protocol
-	RandCommitInterval      = 30 * time.Second // Interval between check of randomness commit
+	// MaxBatchSize is the maximum allowed batch submission size,
+	// this limits BatchSubmissionSize as larger values could cause error due to insufficient fees
+	MaxBatchSize = 100
+	// MaxPubRand is the maximum allowed number of public randomness in each commit,
+	// this limits NumPubRand as larger values could take more than 10min to generate/store
+	// rand proofs
+	MaxPubRand = 500000 //
+	// MinPubRand is the minimum allowed number of public randomness in each commit
+	// a commit with less than this value will be rejected by Babylon Genesis
+	MinPubRand = 8192
+	// TimestampingDelayBlocks is the delay for a commit to become available due to BTC timestamping protocol
+	// it is calculated by converting BTC block time (parameter w=300) to Babylon Genesis block time
+	// 300 BTC blocks * 600s / 10s where 300 BTC blocks is the system parameter of BTC block time required
+	// by the btc timestamping protocol. Adding 12,000 as a buffer in case 300 BTC blocks come with more than
+	// 10min of average time
+	TimestampingDelayBlocks = 18000 + 12000
+	// RandCommitInterval is the interval between each check of whether a new commit needs to be made,
+	// technically this could be a large value depending on NumPubRand, but hardcode a small value for safety
+	RandCommitInterval = 30 * time.Second // Interval between check of randomness commit
 )
 
 var (
@@ -68,7 +82,7 @@ type Config struct {
 	SubmissionRetryInterval     time.Duration `long:"submissionretryinterval" description:"The interval between each attempt to submit finality signature or public randomness after a failure"`
 	SignatureSubmissionInterval time.Duration `long:"signaturesubmissioninterval" description:"The interval between each finality signature(s) submission"`
 
-	// not configurable in config file
+	// not configurable in config file but still keep it here to allow inserting value for e2e tests
 	TimestampingDelayBlocks uint32
 
 	BitcoinNetwork string `long:"bitcoinnetwork" description:"Bitcoin network to run on" choice:"mainnet" choice:"regtest" choice:"testnet" choice:"simnet" choice:"signet"`

--- a/finality-provider/config/config_test.go
+++ b/finality-provider/config/config_test.go
@@ -118,7 +118,6 @@ func TestConfig_Validate(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			err := tt.cfg.Validate()

--- a/finality-provider/config/config_test.go
+++ b/finality-provider/config/config_test.go
@@ -1,0 +1,143 @@
+package config_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/babylonlabs-io/finality-provider/finality-provider/config"
+)
+
+var fpCfg = config.DefaultConfig()
+
+func TestConfig_Validate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		cfg     *config.Config
+		wantErr string
+	}{
+		{
+			name:    "valid config",
+			cfg:     &fpCfg,
+			wantErr: "",
+		},
+		{
+			name:    "nil config",
+			cfg:     nil,
+			wantErr: "config cannot be nil",
+		},
+		{
+			name: "zero signature submission interval",
+			cfg: &config.Config{
+				SignatureSubmissionInterval: 0,
+				SubmissionRetryInterval:     time.Second,
+				BatchSubmissionSize:         100,
+				MaxSubmissionRetries:        50,
+				NumPubRand:                  100,
+				PollerConfig:                defaultPollerConfig(),
+			},
+			wantErr: "timing configuration validation failed: signature submission interval must be positive, got 0s",
+		},
+		{
+			name: "zero submission retry interval",
+			cfg: &config.Config{
+				SignatureSubmissionInterval: time.Second,
+				SubmissionRetryInterval:     0,
+				BatchSubmissionSize:         100,
+				MaxSubmissionRetries:        50,
+				NumPubRand:                  100,
+				PollerConfig:                defaultPollerConfig(),
+			},
+			wantErr: "timing configuration validation failed: submission retry interval must be positive, got 0s",
+		},
+		{
+			name: "zero batch submission size",
+			cfg: &config.Config{
+				SignatureSubmissionInterval: time.Second,
+				SubmissionRetryInterval:     time.Second,
+				BatchSubmissionSize:         0,
+				MaxSubmissionRetries:        50,
+				NumPubRand:                  100,
+				PollerConfig:                defaultPollerConfig(),
+			},
+			wantErr: "batch and retry configuration validation failed: batch submission size must be positive, got 0",
+		},
+		{
+			name: "batch submission size exceeds maximum",
+			cfg: &config.Config{
+				SignatureSubmissionInterval: time.Second,
+				SubmissionRetryInterval:     time.Second,
+				BatchSubmissionSize:         config.MaxBatchSize + 1,
+				MaxSubmissionRetries:        50,
+				NumPubRand:                  100,
+				PollerConfig:                defaultPollerConfig(),
+			},
+			wantErr: "batch and retry configuration validation failed: batch submission size must not exceed 100, got 101",
+		},
+		{
+			name: "zero max submission retries",
+			cfg: &config.Config{
+				SignatureSubmissionInterval: time.Second,
+				SubmissionRetryInterval:     time.Second,
+				BatchSubmissionSize:         100,
+				MaxSubmissionRetries:        0,
+				NumPubRand:                  100,
+				PollerConfig:                defaultPollerConfig(),
+			},
+			wantErr: "batch and retry configuration validation failed: max submission retries must be positive, got 0",
+		},
+		{
+			name: "num pub rand exceeds maximum",
+			cfg: &config.Config{
+				SignatureSubmissionInterval: time.Second,
+				SubmissionRetryInterval:     time.Second,
+				BatchSubmissionSize:         100,
+				MaxSubmissionRetries:        50,
+				NumPubRand:                  config.MaxPubRand + 1,
+				PollerConfig:                defaultPollerConfig(),
+			},
+			wantErr: "batch and retry configuration validation failed: number of public randomness must not exceed 500000, got 500001",
+		},
+		{
+			name: "nil poller config",
+			cfg: &config.Config{
+				SignatureSubmissionInterval: time.Second,
+				SubmissionRetryInterval:     time.Second,
+				BatchSubmissionSize:         100,
+				MaxSubmissionRetries:        50,
+				NumPubRand:                  config.MinPubRand,
+				PollerConfig:                nil,
+			},
+			wantErr: "poller config cannot be empty",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := tt.cfg.Validate()
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+// Helper function to create a default valid ChainPollerConfig for testing
+func defaultPollerConfig() *config.ChainPollerConfig {
+	return &config.ChainPollerConfig{
+		BufferSize:                     1000,
+		PollInterval:                   time.Second,
+		StaticChainScanningStartHeight: 1,
+		AutoChainScanningMode:          true,
+		PollSize:                       1000,
+	}
+}

--- a/finality-provider/config/config_test.go
+++ b/finality-provider/config/config_test.go
@@ -107,6 +107,7 @@ func TestConfig_Validate(t *testing.T) {
 			cfg: &config.Config{
 				SignatureSubmissionInterval: time.Second,
 				SubmissionRetryInterval:     time.Second,
+				TimestampingDelayBlocks:     1,
 				BatchSubmissionSize:         100,
 				MaxSubmissionRetries:        50,
 				NumPubRand:                  config.MinPubRand,

--- a/finality-provider/service/fp_instance.go
+++ b/finality-provider/service/fp_instance.go
@@ -343,7 +343,7 @@ func (fp *FinalityProviderInstance) randomnessCommitmentLoop() {
 
 	fp.processRandomnessCommitment()
 
-	ticker := time.NewTicker(fp.cfg.RandomnessCommitInterval)
+	ticker := time.NewTicker(fpcfg.RandCommitInterval)
 	defer ticker.Stop()
 
 	for {

--- a/itest/test_manager.go
+++ b/itest/test_manager.go
@@ -812,7 +812,7 @@ func defaultFpConfig(keyringDir, homeDir string) *fpcfg.Config {
 
 	cfg.NumPubRand = fpcfg.MinPubRand
 	// to have faster finality activation
-	cfg.TimestampingDelayBlocks = 0
+	cfg.TimestampingDelayBlocks = 1
 
 	cfg.BitcoinNetwork = "simnet"
 	cfg.BTCNetParams = chaincfg.SimNetParams

--- a/itest/test_manager.go
+++ b/itest/test_manager.go
@@ -810,8 +810,8 @@ func (tm *TestManager) InsertBTCDelegation(t *testing.T, fpPks []*btcec.PublicKe
 func defaultFpConfig(keyringDir, homeDir string) *fpcfg.Config {
 	cfg := fpcfg.DefaultConfigWithHome(homeDir)
 
-	cfg.NumPubRand = 1000
-	cfg.NumPubRandMax = 1000
+	cfg.NumPubRand = fpcfg.MinPubRand
+	// to have faster finality activation
 	cfg.TimestampingDelayBlocks = 0
 
 	cfg.BitcoinNetwork = "simnet"


### PR DESCRIPTION
The point of this PR is to ensure that users cannot insert config values that will cause the fp to crash or jailed. Notable changes are:

- Remove config items NumPubRandMax, TimestampingDelayBlocks, RandomnessCommitInterval but hardcode them as they are critical ones that should not be changeable. TimestampingDelayBlocks is calculated based on w=300 and babylon block production time of 10s
- Add validations to config items. Note that MinPubRand to ensure that a commit can pass verification on Babylon side.