### PR TITLE
fix: handle uninitialized commissionInfo when editing fp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * [#399](https://github.com/babylonlabs-io/finality-provider/pull/399) chore: submit immediately
 * [#410](https://github.com/babylonlabs-io/finality-provider/pull/410) chore: rollback sign records from eots store
 * [#413](https://github.com/babylonlabs-io/finality-provider/pull/413) chore: rm default value for app hash flag
+* [#427](https://github.com/babylonlabs-io/finality-provider/pull/427) fix: handle uninitialized commissionInfo when editing fp
 
 ## v1.0.0-rc.2
 

--- a/finality-provider/store/fpstore.go
+++ b/finality-provider/store/fpstore.go
@@ -270,6 +270,9 @@ func (s *FinalityProviderStore) SetFpDescription(btcPk *btcec.PublicKey, desc *s
 		fp.Description = descBytes
 		if rate != nil {
 			fp.Commission = rate.String()
+			if fp.CommissionInfo == nil {
+				fp.CommissionInfo = &proto.CommissionInfo{}
+			}
 			fp.CommissionInfo.UpdateTime = timestamppb.New(time.Now().UTC())
 		}
 


### PR DESCRIPTION
closes #425 