### PR TITLE
Fix: typo README.md edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Finality Provider
 
-Finality providers are key participants in the Babylon BTC staking protocol.
+Finality Providers are key participants in the Babylon BTC staking protocol.
 They provide finality votes on top of
 [CometBFT](https://github.com/cometbft/cometbft), Babylon's consensus mechanism,
 and earn commissions from BTC staking delegations.
 
-The finality provider toolset operates on standard UNIX-based 
+The Finality Provider toolset operates on standard UNIX-based 
 systems and consists of three core components:
 
 1. **Babylon Node**:
@@ -21,7 +21,7 @@ For enhanced security, this component should run on a separate machine or
 network segment.
 3. **Finality Provider Daemon**:
 The core daemon that polls Babylon blocks, commits public randomness, and 
-submits finality signatures. It manages the finality provider's status transitions 
+submits finality signatures. It manages the Finality Provider's status transitions 
 and handles rewards distribution.
 
 **Component Interactions**:
@@ -34,7 +34,7 @@ all EOTS key operations.
 
 ## Become a Finality Provider
 
-For instructions on creating and operating a finality provider,
+For instructions on creating and operating a Finality Provider,
 see our [Finality Provider Guide](./docs/finality-provider-operation.md).
 
 ## High Level Descriptions of EOTS and Finality Provider
@@ -49,34 +49,34 @@ using them to produce EOTS signatures.
 in
 the [Babylon BTC Staking Litepaper](https://docs.babylonchain.io/assets/files/btc_staking_litepaper-32bfea0c243773f0bfac63e148387aef.pdf).
 In short, the EOTS manager generates EOTS public/private randomness pairs. The
-finality provider commits the public part of these pairs to Babylon for every future
-block height that they intend to provide a finality signature for. If the finality
-provider votes for two different blocks on the same height, they will have to reuse
+Finality Provider commits the public part of these pairs to Babylon for every future
+block height that they intend to provide a finality signature for. If the Finality
+Provider votes for two different blocks on the same height, they will have to reuse
 the same private randomness which will lead to their EOTS private key being
 exposed, leading to the slashing. 
 
-Once a finality provider is double-signs, their voting power is immediately reduced
-to zero, while their private key is exposed. A finality provider that double-signs
+Once a Finality Provider double-signs, their voting power is immediately reduced
+to zero, while their private key is exposed. A Finality Provider that double-signs
 can never regain voting power (tombstoning). Additionally, the exposed private key
-of the finality provider can be used to fully sign the slashing transactions of all
+of the Finality Provider can be used to fully sign the slashing transactions of all
 their stake delegations.
 
 The EOTS manager is responsible for the following operations:
 
 1. **EOTS Key Management:**
     - Generates [Schnorr](https://en.wikipedia.org/wiki/Schnorr_signature) key pairs
-      for a given finality provider using the
+      for a given Finality Provider using the
       [BIP-340](https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki)
-      standard as its EOTS key pair
+      standard as its EOTS key pair.
     - Persists generated key pairs in the internal Cosmos keyring.
 2. **Randomness Generation:**
     - Generates lists of EOTS randomness pairs based on the EOTS key, chain ID, and
       block height.
     - The randomness is deterministically generated and tied to specific parameters.
 3. **Signature Generation:**
-    - Signs EOTS using the private key of the finality provider and the corresponding
+    - Signs EOTS using the private key of the Finality Provider and the corresponding
       secret randomness for a given chain at a specified height.
-    - Signs Schnorr signatures using the private key of the finality provider.
+    - Signs Schnorr signatures using the private key of the Finality Provider.
 
 ### Finality Provider
 
@@ -84,17 +84,17 @@ The Finality Provider Daemon is responsible for monitoring for new Babylon block
 committing public randomness for the blocks it intends to provide finality signatures
 for, and submitting finality signatures.
 
-The daemon can manage multiple finality providers but only run a single 
-finality provider instance at a time performing the following operations:
+The daemon can manage multiple Finality Providers but only runs a single 
+Finality Provider instance at a time performing the following operations:
 
-1. **Creation and Registration**: Creates and registers a finality provider to.
+1. **Creation and Registration**: Creates and registers a Finality Provider.
 
 2. **EOTS Randomness Commitment**: The daemon monitors the Babylon chain and commits
-   EOTS public randomness for every Babylon block the finality provider intends to
+   EOTS public randomness for every Babylon block the Finality Provider intends to
    vote for. The commit intervals can be specified in the configuration.
 
 3. **Finality Votes Submission**: The daemon monitors the Babylon chain and produces
-   finality votes for each block the finality provider has committed to vote for.
+   finality votes for each block the Finality Provider has committed to vote for.
 
 4. **Status Management**: The daemon continuously monitors voting power and overall
    provider status. It manages state transitions between `ACTIVE`, `INACTIVE`,
@@ -110,7 +110,7 @@ interacting with the running daemon.
 
 ## Technical Documentation
 
-For detailed technical information about the finality provider's internal operations, see:
+For detailed technical information about the Finality Provider's internal operations, see:
 * [Core Heuristics](./docs/fp-core.md)
 * [Public Randomness Commits](./docs/commit-pub-rand.md)
 * [Finality Votes submission](./docs/send-finality-vote.md)
@@ -121,21 +121,21 @@ For detailed technical information about the finality provider's internal operat
 There are two distinct keys you'll be working with:
 
 - **EOTS Key**:
-    - Used for generating EOTS signatures, Schnorr signatures, and randomness pairs
-    - This serves as the unique identifier for the finality provider
+    - Used for generating EOTS signatures, Schnorr signatures, and randomness pairs.
+    - This serves as the unique identifier for the Finality Provider.
     - It's derived from a Bitcoin private key, using the secp256k1
       elliptic curve.
-    - Stored in the EOTS manager daemon's keyring
+    - Stored in the EOTS manager daemon's keyring.
     - This key is used in the Bitcoin-based security model of Babylon.
 
 - **Babylon Key**:
     - Used for signing transactions on Babylon.
-    - Associated with a Babylon account that receives rewards
-    - Stored in the finality provider daemon's keyring
+    - Associated with a Babylon account that receives rewards.
+    - Stored in the Finality Provider daemon's keyring.
 
-This dual association allows the finality provider to interact with both the
+This dual association allows the Finality Provider to interact with both the
 Bitcoin network (for security) and the Babylon network (for rewards and
 governance).
 
-Once a finality provider is created, neither key can be rotated or changed -
-they are permanently associated with that specific finality provider instance.
+Once a Finality Provider is created, neither key can be rotated or changed -
+they are permanently associated with that specific Finality Provider instance.


### PR DESCRIPTION
- Capitalized "Finality Providers"
- Fixed subject-verb agreement in "The daemon can manage multiple Finality Providers but only run..." to "but only runs"