### PR TITLE
chore: remove bbn address from eots keys - `show` and `list`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * [#436](https://github.com/babylonlabs-io/finality-provider/pull/436) chore: ignore double sign error
 * [#435](https://github.com/babylonlabs-io/finality-provider/pull/435) chore: remove unused bitcoinnetwork config
 * [#447](https://github.com/babylonlabs-io/finality-provider/pull/447) chore: remove the address
-* [#449](https://github.com/babylonlabs-io/finality-provider/pull/449) chore: remove bbn address from eots keys - show and list #449
+* [#449](https://github.com/babylonlabs-io/finality-provider/pull/449) chore: remove bbn address from eots keys - show and list
 
 ## v1.0.0
 

--- a/eotsmanager/cmd/eotsd/daemon/keys.go
+++ b/eotsmanager/cmd/eotsd/daemon/keys.go
@@ -57,10 +57,10 @@ func NewKeysCmd() *cobra.Command {
 
 			eotsPk, err := eotsmanager.LoadBIP340PubKeyFromKeyName(clientCtx.Keyring, args[0])
 			if err != nil {
-				return err
+				return fmt.Errorf("failed to load eots pk from db by key name %s", args[0])
 			}
 
-			cmd.Printf("Key Name: %s\nEOTS PK: %s\n\n", args[0], eotsPk.MarshalHex())
+			cmd.Printf("Key Name: %s\nEOTS PK: %s\n", args[0], eotsPk.MarshalHex())
 
 			return nil
 		}
@@ -257,7 +257,7 @@ func runCommandPrintAllKeys(cmd *cobra.Command, _ []string) error {
 	}
 
 	for _, k := range keys {
-		cmd.Printf("Key Name: %s\nEOTS PK: %s\n\n",
+		cmd.Printf("Key Name: %s\nEOTS PK: %s\n",
 			k.Name, k.EOTSPK)
 	}
 


### PR DESCRIPTION
Unnecessary to use `bbn` address - confusing for users