### PR TITLE
chore: metrics for votes (#450) [backport]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * [#320](https://github.com/babylonlabs-io/finality-provider/pull/320) chore: show `pubkey_hex` at `eotsd keys show` and `eotsd keys list`
 * [#447](https://github.com/babylonlabs-io/finality-provider/pull/447) chore: remove the address
 * [#449](https://github.com/babylonlabs-io/finality-provider/pull/449) chore: remove bbn address from eots keys - show and list
+* [#450](https://github.com/babylonlabs-io/finality-provider/pull/450) chore: metrics for votes
 
 ## v1.0.0
 

--- a/finality-provider/service/fp_instance.go
+++ b/finality-provider/service/fp_instance.go
@@ -739,6 +739,11 @@ func (fp *FinalityProviderInstance) SubmitBatchFinalitySignatures(blocks []*type
 		return nil, err
 	}
 
+	// update the metrics with voted blocks
+	for _, b := range validBlocks {
+		fp.metrics.RecordFpVotedHeight(fp.GetBtcPkHex(), b.Height)
+	}
+
 	// update state with the highest height of this batch even though
 	// some of the votes are skipped due to double sign error
 	highBlock := blocks[len(blocks)-1]

--- a/finality-provider/service/fp_store_adapter.go
+++ b/finality-provider/service/fp_store_adapter.go
@@ -98,6 +98,7 @@ func (fp *FinalityProviderInstance) MustUpdateStateAfterFinalitySigSubmission(he
 		fp.logger.Fatal("failed to update state after finality signature submitted",
 			zap.String("pk", fp.GetBtcPkHex()), zap.Uint64("height", height))
 	}
+	fp.metrics.RecordFpVoteTime(fp.GetBtcPkHex())
 	fp.metrics.RecordFpLastVotedHeight(fp.GetBtcPkHex(), height)
 	fp.metrics.RecordFpLastProcessedHeight(fp.GetBtcPkHex(), height)
 }

--- a/metrics/fp_collectors.go
+++ b/metrics/fp_collectors.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"strconv"
 	"sync"
 	"time"
 
@@ -22,6 +23,7 @@ type FpMetrics struct {
 	fpSecondsSinceLastVote          *prometheus.GaugeVec
 	fpSecondsSinceLastRandomness    *prometheus.GaugeVec
 	fpLastVotedHeight               *prometheus.GaugeVec
+	fpVotedHeight                   *prometheus.GaugeVec
 	fpLastProcessedHeight           *prometheus.GaugeVec
 	fpLastCommittedRandomnessHeight *prometheus.GaugeVec
 	fpTotalBlocksWithoutVotingPower *prometheus.CounterVec
@@ -85,6 +87,13 @@ func NewFpMetrics() *FpMetrics {
 					Help: "The last block height voted by a finality provider.",
 				},
 				[]string{"fp_btc_pk_hex"},
+			),
+			fpVotedHeight: prometheus.NewGaugeVec(
+				prometheus.GaugeOpts{
+					Name: "fp_voted_height",
+					Help: "The block height voted by a finality provider.",
+				},
+				[]string{"fp_btc_pk_hex", "height"},
 			),
 			fpLastProcessedHeight: prometheus.NewGaugeVec(
 				prometheus.GaugeOpts{
@@ -202,6 +211,11 @@ func (fm *FpMetrics) RecordFpSecondsSinceLastRandomness(fpBtcPkHex string, secon
 // RecordFpLastVotedHeight records the last block height voted by a finality provider
 func (fm *FpMetrics) RecordFpLastVotedHeight(fpBtcPkHex string, height uint64) {
 	fm.fpLastVotedHeight.WithLabelValues(fpBtcPkHex).Set(float64(height))
+}
+
+// RecordFpVotedHeight records the block height voted by a finality provider
+func (fm *FpMetrics) RecordFpVotedHeight(fpBtcPkHex string, height uint64) {
+	fm.fpVotedHeight.WithLabelValues(fpBtcPkHex, strconv.FormatUint(height, 10)).SetToCurrentTime()
 }
 
 // RecordFpLastProcessedHeight records the last block height processed by a finality provider


### PR DESCRIPTION
Introduces a new metric `fp_voted_height` so we can query historically voted heights.
func `RecordFpVoteTime` wasn't getting called, and it's important for `fp_seconds_since_last_vote`