### PR TITLE
Update finality provider docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,29 +5,29 @@ They provide finality votes on top of
 [CometBFT](https://github.com/cometbft/cometbft), Babylon's consensus mechanism,
 and earn commissions from BTC staking delegations.
 
-The finality provider toolset operates on standard UNIX-based 
+The finality provider toolset operates on standard UNIX-based
 systems and consists of three core components:
 
-1. **Babylon Node**:
-A Babylon network node that provides chain data and transaction 
-submission capabilities. While not mandatory, running your own node is 
-strongly recommended for security rather than relying on third-party RPC nodes. 
+1. **Babylon Genesis Node**:
+A Babylon Genesis network node that provides chain data and transaction
+submission capabilities. While not mandatory, running your own node is
+strongly recommended for security rather than relying on third-party RPC nodes.
 See the [Setup Node Guide](https://github.com/babylonlabs-io/networks/blob/main/bbn-test-5/babylon-node/README.md) 
 for details.
 2. **Extractable One-Time Signature (EOTS) Manager**:
-A secure key management daemon that handles EOTS key operations, 
-generates extractable one-time signatures, and produces public randomness. 
-For enhanced security, this component should run on a separate machine or 
+A secure key management daemon that handles EOTS key operations,
+generates extractable one-time signatures, and produces public randomness.
+For enhanced security, this component should run on a separate machine or
 network segment.
 3. **Finality Provider Daemon**:
-The core daemon that polls Babylon blocks, commits public randomness, and 
-submits finality signatures. It manages the finality provider's status transitions 
+The core daemon that polls Babylon Genesis blocks, commits public randomness, and
+submits finality signatures. It manages the finality provider's status transitions
 and handles rewards distribution.
 
 **Component Interactions**:
-The Finality Provider daemon communicates with the Babylon Node to monitor blocks 
-and submit transactions. It interacts with the EOTS Manager for signature and 
-randomness generation. The EOTS Manager maintains secure key storage and handles 
+The Finality Provider daemon communicates with the Babylon Genesis Node to monitor blocks
+and submit transactions. It interacts with the EOTS Manager for signature and
+randomness generation. The EOTS Manager maintains secure key storage and handles
 all EOTS key operations.
 
 ![Finality Provider Architecture Diagram](./docs/static/finality-provider-arch.png)
@@ -49,7 +49,7 @@ using them to produce EOTS signatures.
 in
 the [Babylon BTC Staking Litepaper](https://docs.babylonchain.io/assets/files/btc_staking_litepaper-32bfea0c243773f0bfac63e148387aef.pdf).
 In short, the EOTS manager generates EOTS public/private randomness pairs. The
-finality provider commits the public part of these pairs to Babylon for every future
+finality provider commits the public part of these pairs to Babylon Genesis for every future
 block height that they intend to provide a finality signature for. If the finality
 provider votes for two different blocks on the same height, they will have to reuse
 the same private randomness which will lead to their EOTS private key being
@@ -80,20 +80,20 @@ The EOTS manager is responsible for the following operations:
 
 ### Finality Provider
 
-The Finality Provider Daemon is responsible for monitoring for new Babylon blocks,
+The Finality Provider Daemon is responsible for monitoring for new Babylon Genesis blocks,
 committing public randomness for the blocks it intends to provide finality signatures
 for, and submitting finality signatures.
 
-The daemon can manage multiple finality providers but only run a single 
+The daemon can manage multiple finality providers but only run a single
 finality provider instance at a time performing the following operations:
 
 1. **Creation and Registration**: Creates and registers a finality provider to.
 
-2. **EOTS Randomness Commitment**: The daemon monitors the Babylon chain and commits
-   EOTS public randomness for every Babylon block the finality provider intends to
+2. **EOTS Randomness Commitment**: The daemon monitors Babylon Genesis and commits
+   EOTS public randomness for every Babylon Genesis block the finality provider intends to
    vote for. The commit intervals can be specified in the configuration.
 
-3. **Finality Votes Submission**: The daemon monitors the Babylon chain and produces
+3. **Finality Votes Submission**: The daemon monitors Babylon Genesis and produces
    finality votes for each block the finality provider has committed to vote for.
 
 4. **Status Management**: The daemon continuously monitors voting power and overall
@@ -101,8 +101,8 @@ finality provider instance at a time performing the following operations:
    `JAILED`, and `SLASHED` states, while handling the jailing process when violations
    occur.
 
-5. **Security and Key Management**: The daemon manages Babylon keys for signing
-    transactions and rewards distribution. It maintains secure coordination with 
+5. **Security and Key Management**: The daemon manages Babylon Genesis keys for signing
+    transactions and rewards distribution. It maintains secure coordination with
     the EOTS daemon for all key-related operations.
 
 The daemon is controlled by the `fpd` tool, which provides commands for
@@ -128,13 +128,13 @@ There are two distinct keys you'll be working with:
     - Stored in the EOTS manager daemon's keyring
     - This key is used in the Bitcoin-based security model of Babylon.
 
-- **Babylon Key**:
+- **Babylon Genesis Key**:
     - Used for signing transactions on Babylon.
-    - Associated with a Babylon account that receives rewards
+    - Associated with a Babylon Genesis account that receives rewards
     - Stored in the finality provider daemon's keyring
 
 This dual association allows the finality provider to interact with both the
-Bitcoin network (for security) and the Babylon network (for rewards and
+Bitcoin network (for security) and the Babylon Genesis network (for rewards and
 governance).
 
 Once a finality provider is created, neither key can be rotated or changed -

--- a/docs/fp-core.md
+++ b/docs/fp-core.md
@@ -60,7 +60,7 @@ Internal variables need to satisfy the following rules:
   only takes into effect after the committed epoch is finalized. So the finality
   provider should start sending the commit as soon as possible.
 * If the remaining randomness is not sufficient (defined by config) by the
-  current babylon height, the finality provider should make a new commit.
+  current Babylon Genesis height, the finality provider should make a new commit.
 * The next commit should be made with `start_height` right after the last
   committed height. This is to ensure no gap between each commit.
 

--- a/docs/hmac-security.md
+++ b/docs/hmac-security.md
@@ -1,13 +1,13 @@
 # HMAC Security for Finality Provider
 
-This document describes the HMAC (Hash-based Message Authentication Code) authentication system used to secure the 
-communication between the Finality Provider Daemon (FPD) and the Extractable One-Time Signature Daemon (EOTSD). 
+This document describes the HMAC (Hash-based Message Authentication Code) authentication system used to secure the
+communication between the Finality Provider Daemon (FPD) and the Extractable One-Time Signature Daemon (EOTSD).
 HMAC ensures that only authorized requests from FPD are processed by EOTSD, which handles sensitive key operations.
 
 ## Overview
 
-The Finality Provider (FPD) and EOTS Manager (EOTSD) are separate components. EOTSD manages EOTS keys, 
-generates randomness, and signs EOTS signatures and schnorr signatures, making it a critical security target. 
+The Finality Provider (FPD) and EOTS Manager (EOTSD) are separate components. EOTSD manages EOTS keys,
+generates randomness, and signs EOTS signatures and schnorr signatures, making it a critical security target.
 HMAC authentication adds a layer of protection, preventing unauthorized access to these signing capabilities.
 
 ## Security Classification of EOTSD Messages
@@ -44,7 +44,8 @@ Example output: Wt+Nxkn1DpNCFJtxQSxTKoSoKzx1C9XwHTMbT6ir9m0= (Your key will be d
 
 ## Configuration Methods
 
-### 1. FPD Configuration (fpd.conf):
+### 1. FPD Configuration (fpd.conf)
+
 Set the hmackey option within your fpd.conf file:
 
 ```


### PR DESCRIPTION
This PR improves the finality provider doc in general. It covers the following changes:
- Rename Babylon, Babylon network, Babylon blockchain to Babylon Genesis
- Improve `Rewards and Refunding`
  - Remove Refunding part
  - Add `6.3. Set Up Operation Key` to avoid confusion
  - Other small edits