### PR TITLE
chore: unlock cmd hmac and password from input

### DIFF
--- a/eotsmanager/cmd/eotsd/daemon/flags.go
+++ b/eotsmanager/cmd/eotsd/daemon/flags.go
@@ -18,7 +18,8 @@ const (
 	flagIndex             = "index"
 	flagRecover           = "recover"
 	flagMnemonicSrc       = "source"
-	passphraseFlag        = "passphrase"
-	flagDBPath      = "db-path"
-	flagBackupDir   = "backup-dir"
+	flagPassphrase        = "passphrase"
+	flagDBPath            = "db-path"
+	flagBackupDir         = "backup-dir"
+	flagHMAC              = "hmac"
 )

--- a/eotsmanager/cmd/eotsd/daemon/unlock.go
+++ b/eotsmanager/cmd/eotsd/daemon/unlock.go
@@ -5,7 +5,18 @@ import (
 	"fmt"
 	eotsclient "github.com/babylonlabs-io/finality-provider/eotsmanager/client"
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
+	"os"
 )
+
+var UnlockCmdPasswordReader = passwordReader
+
+func passwordReader(cmd *cobra.Command) (string, error) {
+	cmd.Print("Enter password to unlock keyring: ")
+	passphrase, err := term.ReadPassword(int(os.Stdin.Fd()))
+
+	return string(passphrase), err
+}
 
 func NewUnlockKeyringCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -17,13 +28,10 @@ func NewUnlockKeyringCmd() *cobra.Command {
 	f := cmd.Flags()
 
 	f.String(eotsPkFlag, "", "EOTS public key of the finality-provider")
-	f.String(passphraseFlag, "", "The keyring passphrase")
 	f.String(rpcClientFlag, "", "The RPC address of a running eotsd")
+	f.String(flagHMAC, "", "When using HMAC either pass here as flag or set env variable HMAC_KEY.")
 
 	if err := cmd.MarkFlagRequired(eotsPkFlag); err != nil {
-		panic(err)
-	}
-	if err := cmd.MarkFlagRequired(passphraseFlag); err != nil {
 		panic(err)
 	}
 	if err := cmd.MarkFlagRequired(rpcClientFlag); err != nil {
@@ -38,22 +46,32 @@ func unlockKeyring(cmd *cobra.Command, _ []string) error {
 
 	eotsFpPubKeyStr, err := f.GetString(eotsPkFlag)
 	if err != nil {
-		return fmt.Errorf("failed to get eots pk flag: %w", err)
-	}
-
-	passphrase, err := f.GetString(passphraseFlag)
-	if err != nil {
-		return fmt.Errorf("failed to get chain-id flag: %w", err)
+		return fmt.Errorf("failed to get %s flag: %w", eotsPkFlag, err)
 	}
 
 	rpcListener, err := cmd.Flags().GetString(rpcClientFlag)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to get %s flag: %w", rpcClientFlag, err)
 	}
 
-	eotsdClient, err := eotsclient.NewEOTSManagerGRpcClient(rpcListener, "")
+	hmac, err := cmd.Flags().GetString(flagHMAC)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to get %s flag: %w", flagHMAC, err)
+	}
+
+	envHmac, exists := os.LookupEnv("HMAC_KEY")
+	if hmac == "" && exists {
+		hmac = envHmac
+	}
+
+	passphrase, err := UnlockCmdPasswordReader(cmd)
+	if err != nil {
+		return fmt.Errorf("failed to read passphrase: %w", err)
+	}
+
+	eotsdClient, err := eotsclient.NewEOTSManagerGRpcClient(rpcListener, hmac)
+	if err != nil {
+		return fmt.Errorf("failed to create eotsd client: %w", err)
 	}
 
 	eotsFpPub, err := hex.DecodeString(eotsFpPubKeyStr)

--- a/itest/babylon/babylon_e2e_test.go
+++ b/itest/babylon/babylon_e2e_test.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
+	"github.com/spf13/cobra"
 	"log"
 	"math/rand"
 	"os"
@@ -768,10 +769,12 @@ func TestEotsdUnlockCmd(t *testing.T) {
 	require.NoError(t, err)
 
 	const wrongPassphrase = "wrong-passphrase"
+	eotscmd.UnlockCmdPasswordReader = func(_ *cobra.Command) (string, error) {
+		return wrongPassphrase, nil
+	}
 	cmd.SetArgs([]string{
 		"--eots-pk=" + eotsPK.MarshalHex(),
 		"--rpc-client=" + eotsCfg.RPCListener,
-		"--passphrase=" + wrongPassphrase,
 	})
 	err = cmd.Execute()
 	require.Error(t, err)
@@ -779,8 +782,12 @@ func TestEotsdUnlockCmd(t *testing.T) {
 	cmd.SetArgs([]string{
 		"--eots-pk=" + eotsPK.MarshalHex(),
 		"--rpc-client=" + eotsCfg.RPCListener,
-		"--passphrase=" + passphrase,
 	})
+
+	eotscmd.UnlockCmdPasswordReader = func(_ *cobra.Command) (string, error) {
+		return passphrase, nil
+	}
+
 	err = cmd.Execute()
 	require.NoError(t, err)
 


### PR DESCRIPTION
- Provide the user with the option to use HMAC.
- Use a more secure way to read the password for keyring unlock.