### PR TITLE
chore: validate keyring-backend in cfg (#489) [backport]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Improvements
 
 * [#487](https://github.com/babylonlabs-io/finality-provider/pull/487) chore: unlock cmd hmac and password from input
+* [#489](https://github.com/babylonlabs-io/finality-provider/pull/489) chore: validate keyring-backend in cfg
 
 ### Bug Fixes
 

--- a/eotsmanager/cmd/eotsd/daemon/start.go
+++ b/eotsmanager/cmd/eotsd/daemon/start.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"fmt"
+	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	"net"
 
 	sdkflags "github.com/cosmos/cosmos-sdk/client/flags"
@@ -38,7 +39,7 @@ func startFn(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("failed to load config at %s: %w", homePath, err)
 	}
 
-	if cfg.KeyringBackend != "test" && cfg.KeyringBackend != "file" {
+	if cfg.KeyringBackend != keyring.BackendTest && cfg.KeyringBackend != keyring.BackendFile {
 		return fmt.Errorf("the keyring backend in config must be `test` or `file`, got %s", cfg.KeyringBackend)
 	}
 

--- a/eotsmanager/config/config.go
+++ b/eotsmanager/config/config.go
@@ -78,8 +78,8 @@ func LoadConfig(homePath string) (*Config, error) {
 }
 
 // Validate check the given configuration to be sane. This makes sure no
-// illegal values or combination of values are set. All file system paths are
-// normalized. The cleaned up config is returned on success.
+// invalid values or combination of values are set. All file system paths are
+// normalized.
 func (cfg *Config) Validate() error {
 	_, err := net.ResolveTCPAddr("tcp", cfg.RPCListener)
 	if err != nil {
@@ -88,6 +88,10 @@ func (cfg *Config) Validate() error {
 
 	if cfg.KeyringBackend == "" {
 		return fmt.Errorf("the keyring backend should not be empty")
+	}
+
+	if cfg.KeyringBackend != keyring.BackendTest && cfg.KeyringBackend != keyring.BackendFile {
+		return fmt.Errorf("the keyring backend should be be either 'test' or 'file', got '%s'", cfg.KeyringBackend)
 	}
 
 	if cfg.Metrics == nil {


### PR DESCRIPTION
24 Incomplete passphrase validation for keyring backends creates a security risk