### PR TITLE
chore: key migration for test keyring

### DIFF
--- a/eotsmanager/cmd/eotsd/daemon/flags.go
+++ b/eotsmanager/cmd/eotsd/daemon/flags.go
@@ -20,4 +20,5 @@ const (
 	flagMnemonicSrc       = "source"
 	flagDBPath            = "db-path"
 	flagBackupDir         = "backup-dir"
+	flagMigrate           = "migrate"
 )

--- a/eotsmanager/cmd/eotsd/daemon/keysadd.go
+++ b/eotsmanager/cmd/eotsd/daemon/keysadd.go
@@ -283,6 +283,7 @@ func runAddCmd(ctx client.Context, cmd *cobra.Command, args []string, inBuf *buf
 		}
 	}
 
+	fmt.Printf("before NEW ACCOUNT-----------: %s\n", name)
 	_, err = kb.NewAccount(name, mnemonic, bip39Passphrase, hdPath, algo)
 	if err != nil {
 		return err


### PR DESCRIPTION
WIP:

adds flag `--migrate=true` to skip two unnecessary prompts when saving to DB and log