### PR TITLE
rollup: remove dependency to finality gadget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Improvements
 
-* [#517](https://github.com/babylonlabs-io/finality-provider/pull/518) feat: rollup BSN finality provider setup
 * [#493](https://github.com/babylonlabs-io/finality-provider/pull/493) chore: key migration for test keyring
 * [#501](https://github.com/babylonlabs-io/finality-provider/pull/501) chore: signing context
 * [#500](https://github.com/babylonlabs-io/finality-provider/pull/500) feat: fpd abstract poller implementation
@@ -52,6 +51,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * [515](https://github.com/babylonlabs-io/finality-provider/pull/515) chore: abstract randomness committer
 * [#522](https://github.com/babylonlabs-io/finality-provider/pull/522) cli: refactor CLIs and generalise for rollup FPs
 * [516](https://github.com/babylonlabs-io/finality-provider/pull/516) chore: abstract bootstrap
+* [#517](https://github.com/babylonlabs-io/finality-provider/pull/518) feat: rollup BSN finality provider setup
+* [#526](https://github.com/babylonlabs-io/finality-provider/pull/526) rollup: remove dependency to finality gadget
 
 ## v1.1.0-rc.1
 

--- a/bsn/rollup-finality-provider/clientcontroller/consumer.go
+++ b/bsn/rollup-finality-provider/clientcontroller/consumer.go
@@ -93,8 +93,9 @@ func (cc *RollupBSNController) ReliablySendMsg(ctx context.Context, msg sdk.Msg,
 	return cc.reliablySendMsgs(ctx, []sdk.Msg{msg}, expectedErrs, unrecoverableErrs)
 }
 
-// QueryContractConfig queries the finality contract for its config
-func (cc *RollupBSNController) QueryContractConfig(ctx context.Context) (*Config, error) {
+// queryContractConfig queries the finality contract for its config
+// nolint:unused
+func (cc *RollupBSNController) queryContractConfig(ctx context.Context) (*Config, error) {
 	query := QueryMsg{
 		Config: &Config{},
 	}
@@ -394,7 +395,8 @@ func (cc *RollupBSNController) QueryBlock(ctx context.Context, height uint64) (t
 
 // Note: this is specific to the RollupBSNController and only used for testing
 // QueryBlock returns the Ethereum block from a RPC call
-func (cc *RollupBSNController) QueryEthBlock(ctx context.Context, height uint64) (*ethtypes.Header, error) {
+// nolint:unused
+func (cc *RollupBSNController) queryEthBlock(ctx context.Context, height uint64) (*ethtypes.Header, error) {
 	return cc.ethClient.HeaderByNumber(ctx, new(big.Int).SetUint64(height))
 }
 

--- a/bsn/rollup-finality-provider/config/config.go
+++ b/bsn/rollup-finality-provider/config/config.go
@@ -18,9 +18,8 @@ const (
 )
 
 type RollupFPConfig struct {
-	RollupNodeRPCAddress     string `long:"rollup-node-rpc-address" description:"the rpc address of the rollup node to connect to"`
-	BabylonFinalityGadgetRpc string `long:"babylon-finality-gadget-rpc" description:"the rpc address of rollup finality gadget"` //nolint:stylecheck,revive
-	FinalityContractAddress  string `long:"finality-contract-address" description:"the contract address of the rollup finality contract"`
+	RollupNodeRPCAddress    string `long:"rollup-node-rpc-address" description:"the rpc address of the rollup node to connect to"`
+	FinalityContractAddress string `long:"finality-contract-address" description:"the contract address of the rollup finality contract"`
 
 	// Below configurations are needed for the Babylon client
 	Common *fpcfg.Config

--- a/bsn/rollup-finality-provider/e2e/op_test_manager.go
+++ b/bsn/rollup-finality-provider/e2e/op_test_manager.go
@@ -303,9 +303,7 @@ func createRollupFpConfig(
 		FinalityContractAddress: "",
 		// it must be a dialable RPC address checked by NewRollupBSNController
 		RollupNodeRPCAddress: "https://optimism-sepolia.drpc.org",
-		// the value does not matter for the test
-		BabylonFinalityGadgetRpc: "127.0.0.1:50051",
-		Common:                   cfg,
+		Common:               cfg,
 	}
 
 	return opConsumerCfg

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	cosmossdk.io/math v1.5.3
 	github.com/avast/retry-go/v4 v4.5.1
 	github.com/babylonlabs-io/babylon-sdk/demo v0.0.0-20250710070516-a8ad676746c1
-	github.com/babylonlabs-io/finality-gadget v0.1.1
 	github.com/btcsuite/btcd v0.24.2
 	github.com/btcsuite/btcd/btcec/v2 v2.3.4
 	github.com/btcsuite/btcd/btcutil v1.1.6

--- a/go.sum
+++ b/go.sum
@@ -739,8 +739,6 @@ github.com/babylonlabs-io/babylon-sdk/x v0.0.0-20250407051200-a5d652116d6d h1:9z
 github.com/babylonlabs-io/babylon-sdk/x v0.0.0-20250407051200-a5d652116d6d/go.mod h1:ks4/p72aNJTIN8+CnCFxNX0HqfgHdClEwU4LxAxryJQ=
 github.com/babylonlabs-io/babylon/v3 v3.0.0-snapshot.250711 h1:l95QWwd3hGek0LYiYGp+8I8ljADXApRbshugjMg+1Oo=
 github.com/babylonlabs-io/babylon/v3 v3.0.0-snapshot.250711/go.mod h1:/X1bVC4WUKDBxRTazXvZd/6WINc2tqXAtZOBJknM8OA=
-github.com/babylonlabs-io/finality-gadget v0.1.1 h1:izW+sxtrsVPC9FlGx0wzWTJqRk+buEw9zfV7nXKQmWA=
-github.com/babylonlabs-io/finality-gadget v0.1.1/go.mod h1:+BICJA7mUJpfYOSYds1G5w6nLO0gKVe9XwdmpIUiXmk=
 github.com/babylonlabs-io/tokenfactory v0.50.6-wasmvm2 h1:7wtBLjwncBsYgc+LlW4eir/bGcycrhpbz7PkUVADzBc=
 github.com/babylonlabs-io/tokenfactory v0.50.6-wasmvm2/go.mod h1:L8XfncoH1M6fOrzqfRVQZePqo54ZlTDdatUpEr0Iz/E=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=


### PR DESCRIPTION
Resolves #503 

This PR removes the dependency to finality gadget in `rollup-fpd`, removes certain unused varaibles/functions, and makes certain functions private.