### PR TITLE
docs: add rollup fp operation

### DIFF
--- a/docs/eots-daemon.md
+++ b/docs/eots-daemon.md
@@ -55,6 +55,7 @@ This command will:
 * Install binaries to `$GOPATH/bin`:
   * `eotsd`: EOTS manager daemon
   * `fpd`: Finality provider daemon.
+  * All BSN finality provider deamon (e.g., `rollup-fpd`, etc.)
 * Make commands globally accessible from your terminal.
 
 ### 1.3. Verify Installation


### PR DESCRIPTION
## Description

This PR adds fp operation guide. This guide has same section as [babylon genesis operation guide](https://github.com/babylonlabs-io/finality-provider/blob/main/docs/finality-provider-operation.md). And most sections are copy/paste and modified to match `rollup-fpd` binary

## Manually tested:
- [ ] Setting up EOTSD
- [ ] Setting up and starting finality provider
- [ ] Registering finality provider
- [ ] Fetching status
- [ ] Editing finality provider
- [ ] Rewards
- [ ] Recovering local state
- [ ] Recovering public randomness proof