### PR TITLE
chore: bump bbn for v2 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
   e2e cosmos bsn
 * [#570](https://github.com/babylonlabs-io/finality-provider/pull/570)
   chore(rollup): don't allow FP program to start if not in allowlist
+* [#580](https://github.com/babylonlabs-io/finality-provider/pull/580) chore: bump bbn for v2 compatibility
 
 ## v1.1.0-rc.1
 

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/avast/retry-go/v4 v4.5.1
 	github.com/babylonlabs-io/babylon-sdk/demo v0.0.0-20250801111417-fe7557c41640
 	github.com/babylonlabs-io/babylon-sdk/x v0.0.0-20250801111417-fe7557c41640
-	github.com/babylonlabs-io/babylon/v3 v3.0.0-snapshot.250724
+	github.com/babylonlabs-io/babylon/v3 v3.0.0-snapshot.250805a
 	github.com/btcsuite/btcd v0.24.2
 	github.com/btcsuite/btcd/btcec/v2 v2.3.5
 	github.com/btcsuite/btcd/btcutil v1.1.6
@@ -357,7 +357,6 @@ replace (
 	cosmossdk.io/core => cosmossdk.io/core v0.11.3
 	// use cosmos fork of keyring
 	github.com/99designs/keyring => github.com/cosmos/keyring v1.2.0
-	github.com/babylonlabs-io/babylon/v3 => github.com/babylonlabs-io/babylon/v3 v3.0.0-20250805132433-52134aab621e
 	github.com/ethereum/go-ethereum => github.com/cosmos/go-ethereum v1.15.11-cosmos-0
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/strangelove-ventures/tokenfactory => github.com/babylonlabs-io/tokenfactory v0.50.6-wasmvm2

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/avast/retry-go/v4 v4.5.1
 	github.com/babylonlabs-io/babylon-sdk/demo v0.0.0-20250801111417-fe7557c41640
 	github.com/babylonlabs-io/babylon-sdk/x v0.0.0-20250801111417-fe7557c41640
+	github.com/babylonlabs-io/babylon/v3 v3.0.0-snapshot.250724
 	github.com/btcsuite/btcd v0.24.2
 	github.com/btcsuite/btcd/btcec/v2 v2.3.5
 	github.com/btcsuite/btcd/btcutil v1.1.6
@@ -125,7 +126,6 @@ require (
 	github.com/aead/siphash v1.0.1 // indirect
 	github.com/andybalholm/brotli v1.1.0 // indirect
 	github.com/aws/aws-sdk-go v1.49.0 // indirect
-	github.com/babylonlabs-io/babylon/v3 v3.0.0-snapshot.250729
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d // indirect
 	github.com/bgentry/speakeasy v0.2.0 // indirect
@@ -357,6 +357,7 @@ replace (
 	cosmossdk.io/core => cosmossdk.io/core v0.11.3
 	// use cosmos fork of keyring
 	github.com/99designs/keyring => github.com/cosmos/keyring v1.2.0
+	github.com/babylonlabs-io/babylon/v3 => github.com/babylonlabs-io/babylon/v3 v3.0.0-20250805132433-52134aab621e
 	github.com/ethereum/go-ethereum => github.com/cosmos/go-ethereum v1.15.11-cosmos-0
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/strangelove-ventures/tokenfactory => github.com/babylonlabs-io/tokenfactory v0.50.6-wasmvm2

--- a/go.sum
+++ b/go.sum
@@ -739,8 +739,8 @@ github.com/babylonlabs-io/babylon-sdk/tests/e2e v0.0.0-20250801111417-fe7557c416
 github.com/babylonlabs-io/babylon-sdk/tests/e2e v0.0.0-20250801111417-fe7557c41640/go.mod h1:KEu5zoOSTTJyyAzTqVKHIt8jyDaMxzxrMS9WjffoAdA=
 github.com/babylonlabs-io/babylon-sdk/x v0.0.0-20250801111417-fe7557c41640 h1:0znOGQ1Mh0l7OrGKGiN9Jd/Vu/YZ6LMmTSoiqIYoHmI=
 github.com/babylonlabs-io/babylon-sdk/x v0.0.0-20250801111417-fe7557c41640/go.mod h1:seS4E882FYvlzi07MpIgtCtcC7AISJp1oo30AWMbGfE=
-github.com/babylonlabs-io/babylon/v3 v3.0.0-20250805132433-52134aab621e h1:mZHPuEK1j4AbidlyR0allDGjfZHm0YLV4cCy+UO5yoY=
-github.com/babylonlabs-io/babylon/v3 v3.0.0-20250805132433-52134aab621e/go.mod h1:7QpvIvZTClWlm1hNz4ivb3I522XrOJC5UcnqDGiwi08=
+github.com/babylonlabs-io/babylon/v3 v3.0.0-snapshot.250805a h1:RHqL0xoYuFf575ViZsQszSR0DnyjWx6BrKUqlrrWNS0=
+github.com/babylonlabs-io/babylon/v3 v3.0.0-snapshot.250805a/go.mod h1:7QpvIvZTClWlm1hNz4ivb3I522XrOJC5UcnqDGiwi08=
 github.com/babylonlabs-io/tokenfactory v0.50.6-wasmvm2 h1:7wtBLjwncBsYgc+LlW4eir/bGcycrhpbz7PkUVADzBc=
 github.com/babylonlabs-io/tokenfactory v0.50.6-wasmvm2/go.mod h1:L8XfncoH1M6fOrzqfRVQZePqo54ZlTDdatUpEr0Iz/E=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=

--- a/go.sum
+++ b/go.sum
@@ -739,8 +739,8 @@ github.com/babylonlabs-io/babylon-sdk/tests/e2e v0.0.0-20250801111417-fe7557c416
 github.com/babylonlabs-io/babylon-sdk/tests/e2e v0.0.0-20250801111417-fe7557c41640/go.mod h1:KEu5zoOSTTJyyAzTqVKHIt8jyDaMxzxrMS9WjffoAdA=
 github.com/babylonlabs-io/babylon-sdk/x v0.0.0-20250801111417-fe7557c41640 h1:0znOGQ1Mh0l7OrGKGiN9Jd/Vu/YZ6LMmTSoiqIYoHmI=
 github.com/babylonlabs-io/babylon-sdk/x v0.0.0-20250801111417-fe7557c41640/go.mod h1:seS4E882FYvlzi07MpIgtCtcC7AISJp1oo30AWMbGfE=
-github.com/babylonlabs-io/babylon/v3 v3.0.0-snapshot.250729 h1:fD28AB6TNSq7TQ1FaeOYUZdUfBN/qNwVBG7+M4bLyCQ=
-github.com/babylonlabs-io/babylon/v3 v3.0.0-snapshot.250729/go.mod h1:7QpvIvZTClWlm1hNz4ivb3I522XrOJC5UcnqDGiwi08=
+github.com/babylonlabs-io/babylon/v3 v3.0.0-20250805132433-52134aab621e h1:mZHPuEK1j4AbidlyR0allDGjfZHm0YLV4cCy+UO5yoY=
+github.com/babylonlabs-io/babylon/v3 v3.0.0-20250805132433-52134aab621e/go.mod h1:7QpvIvZTClWlm1hNz4ivb3I522XrOJC5UcnqDGiwi08=
 github.com/babylonlabs-io/tokenfactory v0.50.6-wasmvm2 h1:7wtBLjwncBsYgc+LlW4eir/bGcycrhpbz7PkUVADzBc=
 github.com/babylonlabs-io/tokenfactory v0.50.6-wasmvm2/go.mod h1:L8XfncoH1M6fOrzqfRVQZePqo54ZlTDdatUpEr0Iz/E=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=

--- a/itest/container/config.go
+++ b/itest/container/config.go
@@ -33,7 +33,7 @@ func NewImageConfig(t *testing.T) ImageConfig {
 	// babylondVersion, err := testutil.GetBabylonVersion()
 	babylondVersion, err := testutil.GetBabylonCommitHash()
 	require.NoError(t, err)
-	babylondVersion = "52134aab621e7cea43319af9c4c9697a37979399"
+	
 	return ImageConfig{
 		BabylonRepository:     dockerBabylondRepository,
 		BabylonVersion:        babylondVersion,

--- a/itest/container/config.go
+++ b/itest/container/config.go
@@ -33,6 +33,7 @@ func NewImageConfig(t *testing.T) ImageConfig {
 	// babylondVersion, err := testutil.GetBabylonVersion()
 	babylondVersion, err := testutil.GetBabylonCommitHash()
 	require.NoError(t, err)
+	babylondVersion = "52134aab621e7cea43319af9c4c9697a37979399"
 	return ImageConfig{
 		BabylonRepository:     dockerBabylondRepository,
 		BabylonVersion:        babylondVersion,


### PR DESCRIPTION
We want fp v2 to be compatible with bbn v2, this bump makes that possible