### PR TITLE
chore: make cosmos e2e run in parallel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## Unreleased
 
+### Improvements
+
+* [#606](https://github.com/babylonlabs-io/finality-provider/pull/606) chore: make cosmos e2e run in parallel
+
 ## v2.0.0-rc.1
 
 ### Improvements

--- a/bsn/cosmos/e2e/bcd_consumer_e2e_test.go
+++ b/bsn/cosmos/e2e/bcd_consumer_e2e_test.go
@@ -1,3 +1,5 @@
+//go:build e2e_bcd
+
 package e2etest_bcd
 
 import (

--- a/bsn/cosmos/e2e/bcd_consumer_e2e_test.go
+++ b/bsn/cosmos/e2e/bcd_consumer_e2e_test.go
@@ -1,11 +1,8 @@
-//go:build e2e_bcd
-
 package e2etest_bcd
 
 import (
 	"context"
 	"encoding/json"
-	bbnappparams "github.com/babylonlabs-io/babylon-sdk/demo/app/params"
 	appparams "github.com/babylonlabs-io/babylon/v3/app/params"
 	"github.com/babylonlabs-io/finality-provider/bsn/cosmos/cmd/cosmos-fpd/daemon"
 	"github.com/babylonlabs-io/finality-provider/bsn/cosmos/config"
@@ -42,7 +39,8 @@ import (
 // has started. This order is critical because the pub randomness loop takes time to initialize,
 // and without it, blocks won't get finalized properly.
 func TestConsumerFpLifecycle(t *testing.T) {
-	appparams.SetAddressPrefixes()
+	t.Parallel()
+	setBbnAddressPrefixesSafely()
 
 	ctx, cancel := context.WithCancel(t.Context())
 	ctm := StartBcdTestManager(t, ctx)
@@ -85,9 +83,9 @@ func TestConsumerFpLifecycle(t *testing.T) {
 
 	// inject delegation in smart contract using admin
 	// HACK: set account prefix to ensure the staker's address uses bbn prefix
-	appparams.SetAddressPrefixes()
+	setBbnAddressPrefixesSafely()
 	delMsg := e2eutils.GenBtcStakingDelExecMsg(fpPk.MarshalHex())
-	bbnappparams.SetAddressPrefixes()
+	setBbncAppPrefixesSafely()
 	delMsgBytes, err := json.Marshal(delMsg)
 	require.NoError(t, err)
 	_, err = ctm.BcdConsumerClient.ExecuteBTCStakingContract(ctx, delMsgBytes)
@@ -137,7 +135,8 @@ func TestConsumerFpLifecycle(t *testing.T) {
 // 6. Execute the recover-proof command to restore proofs from smart contract
 // 7. Verify that public randomness proofs are successfully recovered in the database
 func TestConsumerRecoverRandProofCmd(t *testing.T) {
-	appparams.SetAddressPrefixes()
+	t.Parallel()
+	setBbnAddressPrefixesSafely()
 
 	ctx, cancel := context.WithCancel(t.Context())
 	ctm := StartBcdTestManager(t, ctx)
@@ -176,9 +175,9 @@ func TestConsumerRecoverRandProofCmd(t *testing.T) {
 
 	// inject delegation in smart contract using admin
 	// HACK: set account prefix to ensure the staker's address uses bbn prefix
-	appparams.SetAddressPrefixes()
+	setBbnAddressPrefixesSafely()
 	delMsg := e2eutils.GenBtcStakingDelExecMsg(fpPk.MarshalHex())
-	bbnappparams.SetAddressPrefixes()
+	setBbncAppPrefixesSafely()
 	delMsgBytes, err := json.Marshal(delMsg)
 	require.NoError(t, err)
 	_, err = ctm.BcdConsumerClient.ExecuteBTCStakingContract(ctx, delMsgBytes)

--- a/bsn/cosmos/e2e/bcd_handler.go
+++ b/bsn/cosmos/e2e/bcd_handler.go
@@ -1,11 +1,10 @@
-//go:build e2e_bcd
-
 package e2etest_bcd
 
 import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/babylonlabs-io/finality-provider/testutil"
 	"io"
 	"log"
 	"os"
@@ -22,16 +21,13 @@ import (
 )
 
 const (
-	bcdRpcPort    int = 3990
-	bcdP2pPort    int = 3991
-	bcdChainID        = "bcd-test"
-	bcdConsumerID     = "07-tendermint-0"
+	bcdChainID    = "bcd-test"
+	bcdConsumerID = "07-tendermint-0"
 
 	// Relayer constants
-	relayerAPIPort int = 5183
-	babylonKey         = "babylon-key"
-	consumerKey        = "bcd-key"
-	pathName           = "bcd"
+	babylonKey  = "babylon-key"
+	consumerKey = "bcd-key"
+	pathName    = "bcd"
 )
 
 type BcdNodeHandler struct {
@@ -42,6 +38,10 @@ type BcdNodeHandler struct {
 	dataDir         string
 	relayerHomeDir  string
 	contractAddress string
+	bcdRpcPort      int
+	bcdP2pPort      int
+	bcdGrpcPort     int
+	relayerAPIPort  int
 
 	babylonChainID string
 	babylonNodeRPC string
@@ -106,7 +106,12 @@ func NewBcdNodeHandler(t *testing.T) *BcdNodeHandler {
 	require.NoError(t, err)
 
 	setupBcd(t, testDir)
-	cmd := bcdStartCmd(t, testDir)
+
+	rpcPort := testutil.AllocateUniquePort(t)
+	p2pPort := testutil.AllocateUniquePort(t)
+	grpcPort := testutil.AllocateUniquePort(t)
+
+	cmd := bcdStartCmd(t, testDir, rpcPort, p2pPort, grpcPort)
 	t.Log("Starting bcd with command:", cmd.String())
 	t.Log("Test directory:", testDir)
 	t.Log("Relayer directory:", relayerDir)
@@ -117,6 +122,9 @@ func NewBcdNodeHandler(t *testing.T) *BcdNodeHandler {
 		relayerPidFile: "",
 		dataDir:        testDir,
 		relayerHomeDir: relayerDir,
+		bcdP2pPort:     p2pPort,
+		bcdRpcPort:     rpcPort,
+		bcdGrpcPort:    grpcPort,
 		// These should be set by the caller based on their setup
 		babylonChainID: "chain-test",
 		babylonNodeRPC: "http://localhost:26657", // Default, should be configured
@@ -152,6 +160,8 @@ func (w *BcdNodeHandler) StartRelayer(t *testing.T) error {
 		}
 		w.contractAddress = contractAddr
 	}
+
+	w.relayerAPIPort = testutil.AllocateUniquePort(t)
 
 	// Setup relayer
 	if err := w.setupRelayer(t); err != nil {
@@ -300,8 +310,8 @@ paths:
             chain-id: %s
         dst:
             chain-id: %s
-`, relayerAPIPort, babylonKey, w.babylonChainID, w.babylonNodeRPC,
-		consumerKey, bcdChainID, bcdRpcPort,
+`, w.relayerAPIPort, babylonKey, w.babylonChainID, w.babylonNodeRPC,
+		consumerKey, bcdChainID, w.bcdRpcPort,
 		pathName, w.babylonChainID, bcdChainID)
 
 	configPath := filepath.Join(w.relayerHomeDir, "config", "config.yaml")
@@ -585,7 +595,7 @@ func (w *BcdNodeHandler) stopRelayer() error {
 }
 
 func (w *BcdNodeHandler) GetRpcUrl() string {
-	return fmt.Sprintf("http://localhost:%d", bcdRpcPort)
+	return fmt.Sprintf("http://localhost:%d", w.bcdRpcPort)
 }
 
 func (w *BcdNodeHandler) GetHomeDir() string {
@@ -788,12 +798,13 @@ func setupBcd(t *testing.T, testDir string) {
 	require.NoError(t, err)
 }
 
-func bcdStartCmd(t *testing.T, testDir string) *exec.Cmd {
+func bcdStartCmd(t *testing.T, testDir string, rpcPort, p2pPort, grpcPort int) *exec.Cmd {
 	args := []string{
 		"start",
 		"--home", testDir,
-		"--rpc.laddr", fmt.Sprintf("tcp://0.0.0.0:%d", bcdRpcPort),
-		"--p2p.laddr", fmt.Sprintf("tcp://0.0.0.0:%d", bcdP2pPort),
+		"--rpc.laddr", fmt.Sprintf("tcp://0.0.0.0:%d", rpcPort),
+		"--p2p.laddr", fmt.Sprintf("tcp://0.0.0.0:%d", p2pPort),
+		"--grpc.address", fmt.Sprintf("0.0.0.0:%d", grpcPort),
 		"--log_level=info",
 	}
 

--- a/bsn/cosmos/e2e/bcd_handler.go
+++ b/bsn/cosmos/e2e/bcd_handler.go
@@ -1,3 +1,5 @@
+//go:build e2e_bcd
+
 package e2etest_bcd
 
 import (

--- a/bsn/cosmos/e2e/bcd_test_manager.go
+++ b/bsn/cosmos/e2e/bcd_test_manager.go
@@ -1,3 +1,5 @@
+//go:build e2e_bcd
+
 package e2etest_bcd
 
 import (
@@ -90,7 +92,7 @@ type BcdTestManager struct {
 //
 // This creates a race condition when tests run in parallel (t.Parallel()):
 //   - Test A calls SetAddressPrefixes() to set "bbn" prefix
-//   - Test B calls SetAddressPrefixes() to set "bbnc" prefix  
+//   - Test B calls SetAddressPrefixes() to set "bbnc" prefix
 //   - Both tests read the global config simultaneously, causing unpredictable behavior
 //
 // The mutex ensures that only one goroutine can modify address prefixes at a time,

--- a/bsn/cosmos/e2e/bcd_test_manager.go
+++ b/bsn/cosmos/e2e/bcd_test_manager.go
@@ -1,5 +1,3 @@
-//go:build e2e_bcd
-
 package e2etest_bcd
 
 import (
@@ -7,9 +5,11 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	bbnappparams "github.com/babylonlabs-io/babylon-sdk/demo/app/params"
 	appparams "github.com/babylonlabs-io/babylon/v3/app/params"
 	config2 "github.com/babylonlabs-io/finality-provider/bsn/cosmos/cosmwasmclient/config"
 	"strings"
+	"sync"
 
 	sdkErr "cosmossdk.io/errors"
 	wasmdtypes "github.com/CosmWasm/wasmd/x/wasm/types"
@@ -46,12 +46,6 @@ import (
 	bbnclient "github.com/babylonlabs-io/babylon/v3/client/client"
 	"github.com/babylonlabs-io/babylon/v3/testutil/datagen"
 	bbntypes "github.com/babylonlabs-io/babylon/v3/types"
-	dbm "github.com/cosmos/cosmos-db"
-	simtestutil "github.com/cosmos/cosmos-sdk/testutil/sims"
-	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
-
 	ccapi "github.com/babylonlabs-io/finality-provider/clientcontroller/api"
 	bbncc "github.com/babylonlabs-io/finality-provider/clientcontroller/babylon"
 	"github.com/babylonlabs-io/finality-provider/eotsmanager/client"
@@ -63,6 +57,10 @@ import (
 	base_test_manager "github.com/babylonlabs-io/finality-provider/itest/test-manager"
 	"github.com/babylonlabs-io/finality-provider/testutil"
 	"github.com/babylonlabs-io/finality-provider/types"
+	dbm "github.com/cosmos/cosmos-db"
+	simtestutil "github.com/cosmos/cosmos-sdk/testutil/sims"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 )
 
 type BcdTestManager struct {
@@ -83,16 +81,37 @@ type BcdTestManager struct {
 	babylonKeyDir     string
 }
 
-func createLogger(t *testing.T, level zapcore.Level) *zap.Logger {
-	config := zap.NewDevelopmentConfig()
-	config.Level = zap.NewAtomicLevelAt(level)
-	logger, err := config.Build()
-	require.NoError(t, err)
-	return logger
+// addressPrefixMutex serializes access to Cosmos SDK address prefix configuration.
+//
+// The Cosmos SDK uses a global singleton configuration (sdk.GetConfig()) to store
+// address prefixes for bech32 encoding. Functions like appparams.SetAddressPrefixes()
+// and bbnappparams.SetAddressPrefixes() modify this global state by calling
+// sdk.GetConfig().SetBech32PrefixForAccount() and related methods.
+//
+// This creates a race condition when tests run in parallel (t.Parallel()):
+//   - Test A calls SetAddressPrefixes() to set "bbn" prefix
+//   - Test B calls SetAddressPrefixes() to set "bbnc" prefix  
+//   - Both tests read the global config simultaneously, causing unpredictable behavior
+//
+// The mutex ensures that only one goroutine can modify address prefixes at a time,
+// preventing race conditions while still allowing tests to run in parallel.
+// The critical sections are kept minimal to reduce lock contention.
+var addressPrefixMutex sync.Mutex
+
+func setBbnAddressPrefixesSafely() {
+	addressPrefixMutex.Lock()
+	defer addressPrefixMutex.Unlock()
+	appparams.SetAddressPrefixes()
+}
+
+func setBbncAppPrefixesSafely() {
+	addressPrefixMutex.Lock()
+	defer addressPrefixMutex.Unlock()
+	bbnappparams.SetAddressPrefixes()
 }
 
 func StartBcdTestManager(t *testing.T, ctx context.Context) *BcdTestManager {
-	appparams.SetAddressPrefixes()
+	setBbnAddressPrefixesSafely()
 
 	testDir, err := base_test_manager.TempDir(t, "fp-e2e-test-*")
 	require.NoError(t, err)
@@ -159,9 +178,10 @@ func StartBcdTestManager(t *testing.T, ctx context.Context) *BcdTestManager {
 	cosmwasmConfig.BtcFinalityContractAddress = datagen.GenRandomAccount().GetAddress().String()
 	cosmwasmConfig.AccountPrefix = "bbnc"
 	cosmwasmConfig.ChainID = bcdChainID
-	cosmwasmConfig.RPCAddr = fmt.Sprintf("http://localhost:%d", bcdRpcPort)
+	cosmwasmConfig.RPCAddr = fmt.Sprintf("http://localhost:%d", wh.bcdRpcPort)
 	cosmwasmConfig.GasPrices = "0.01ustake"
 	cosmwasmConfig.GasAdjustment = 2.0
+	cosmwasmConfig.GRPCAddr = fmt.Sprintf("tcp://localhost:%d", wh.bcdGrpcPort)
 
 	// tempApp := bcdapp.NewTmpApp() // TODO: investigate why wasmapp works and bcdapp doesn't
 	tempApp := wasmapp.NewWasmApp(sdklogs.NewNopLogger(), dbm.NewMemDB(), nil, false, simtestutil.NewAppOptionsWithFlagHome(t.TempDir()), []wasmkeeper.Option{})


### PR DESCRIPTION
Cosmos e2e tests take way too long to run sequentially, now makes them parallel

closes #599 