### PR TITLE
chore: default poll size rollup (#610)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * [#606](https://github.com/babylonlabs-io/finality-provider/pull/606) chore: make cosmos e2e run in parallel
 * [#607](https://github.com/babylonlabs-io/finality-provider/pull/607) chore: impl missing methods in cc for cosmos
 * [#608](https://github.com/babylonlabs-io/finality-provider/pull/608) chore: fix data race in bcd e2e
+* [#610](https://github.com/babylonlabs-io/finality-provider/pull/610) chore: default poll size rollup
 
 ## v2.0.0-rc.1
 

--- a/bsn/rollup/config/config.go
+++ b/bsn/rollup/config/config.go
@@ -15,6 +15,8 @@ const (
 	defaultConfigFileName = "fpd.conf"
 	defaultLogDirname     = "logs"
 	defaultLogFilename    = "fpd.log"
+	// defaultPollSize is different from the default in fpcfg.Config to avoid rate limiting
+	defaultPollSize = uint32(100)
 )
 
 type RollupFPConfig struct {
@@ -82,6 +84,7 @@ func LoadConfig(homePath string) (*RollupFPConfig, error) {
 
 func DefaultConfigWithHome(homePath string) RollupFPConfig {
 	cfg := fpcfg.DefaultConfigWithHome(homePath)
+	cfg.PollerConfig.PollSize = defaultPollSize
 
 	return RollupFPConfig{
 		Common: &cfg,


### PR DESCRIPTION
Change the default to 100 to avoid rate limits