### PR TITLE
chore: unify proof building (#634)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## Unreleased
 
+### Improvements
+
+* [#634](https://github.com/babylonlabs-io/finality-provider/pull/634) chore: unify proof building
+
 ## v2.0.0-rc.2
 
 ### Bug fixes

--- a/bsn/rollup/cmd/rollup-fpd/daemon/recover_proof.go
+++ b/bsn/rollup/cmd/rollup-fpd/daemon/recover_proof.go
@@ -73,7 +73,7 @@ func runCommandRecoverProof(ctx client.Context, cmd *cobra.Command, args []strin
 				return fmt.Errorf("expected RollupPubRandCommit, got %T", commit)
 			}
 
-			if err := pubRandStore.AddPubRandProofListWithInterval(chainID, pk, commit.GetStartHeight(), commit.GetNumPubRand(), proofList, concreteCommit.Interval); err != nil {
+			if err := pubRandStore.AddPubRandProofList(chainID, pk, commit.GetStartHeight(), commit.GetNumPubRand(), proofList, store.WithInterval(concreteCommit.Interval)); err != nil {
 				return fmt.Errorf("failed to save public randomness to DB: %w", err)
 			}
 

--- a/finality-provider/service/pub_rand_store_adapter.go
+++ b/finality-provider/service/pub_rand_store_adapter.go
@@ -23,21 +23,10 @@ func NewPubRandState(s *store.PubRandProofStore) *PubRandState {
 
 func (st *PubRandState) addPubRandProofList(
 	pk, chainID []byte, height uint64, numPubRand uint64,
-	proofList []*merkle.Proof,
+	proofList []*merkle.Proof, options ...store.KeyBuildOption,
 ) error {
-	if err := st.s.AddPubRandProofList(chainID, pk, height, numPubRand, proofList); err != nil {
+	if err := st.s.AddPubRandProofList(chainID, pk, height, numPubRand, proofList, options...); err != nil {
 		return fmt.Errorf("failed to add pub rand proof list: %w", err)
-	}
-
-	return nil
-}
-
-func (st *PubRandState) addPubRandProofListWithInterval(
-	pk, chainID []byte, startHeight uint64, numPubRand uint64,
-	proofList []*merkle.Proof, interval uint64,
-) error {
-	if err := st.s.AddPubRandProofListWithInterval(chainID, pk, startHeight, numPubRand, proofList, interval); err != nil {
-		return fmt.Errorf("failed to add pub rand proof list with interval: %w", err)
 	}
 
 	return nil

--- a/finality-provider/service/rand_committer.go
+++ b/finality-provider/service/rand_committer.go
@@ -7,6 +7,7 @@ import (
 	bbntypes "github.com/babylonlabs-io/babylon/v3/types"
 	ccapi "github.com/babylonlabs-io/finality-provider/clientcontroller/api"
 	"github.com/babylonlabs-io/finality-provider/eotsmanager"
+	"github.com/babylonlabs-io/finality-provider/finality-provider/store"
 	"github.com/babylonlabs-io/finality-provider/metrics"
 	"github.com/babylonlabs-io/finality-provider/types"
 	"github.com/btcsuite/btcd/btcec/v2"
@@ -301,7 +302,7 @@ func (rc *DefaultRandomnessCommitter) GetPubRandProofList(height uint64, numPubR
 	return proofList, nil
 }
 func (rc *DefaultRandomnessCommitter) AddPubRandProofListWithInterval(startHeight uint64, numPubRand uint64, proofList []*merkle.Proof, interval uint64) error {
-	err := rc.PubRandState.addPubRandProofListWithInterval(rc.BtcPk.MustMarshal(), rc.Cfg.ChainID, startHeight, numPubRand, proofList, interval)
+	err := rc.PubRandState.addPubRandProofList(rc.BtcPk.MustMarshal(), rc.Cfg.ChainID, startHeight, numPubRand, proofList, store.WithInterval(interval))
 	if err != nil {
 		return fmt.Errorf("failed to add public randomness proof list with interval: %w", err)
 	}

--- a/finality-provider/store/pub_rand.go
+++ b/finality-provider/store/pub_rand.go
@@ -68,22 +68,33 @@ func getPrefixKey(chainID, pk []byte) []byte {
 	return prefix
 }
 
-func buildKeys(chainID, pk []byte, height uint64, num uint64) [][]byte {
-	keys := make([][]byte, 0, num)
-
-	for i := uint64(0); i < num; i++ {
-		key := getKey(chainID, pk, height+i)
-		keys = append(keys, key)
-	}
-
-	return keys
+type KeyBuildOptions struct {
+	interval uint64
 }
 
-func buildKeysWithInterval(chainID, pk []byte, startHeight uint64, num uint64, interval uint64) [][]byte {
+// KeyBuildOption is a function that modifies KeyBuildOptions
+type KeyBuildOption func(*KeyBuildOptions)
+
+// WithInterval sets the interval between consecutive heights
+func WithInterval(interval uint64) KeyBuildOption {
+	return func(opts *KeyBuildOptions) {
+		opts.interval = interval
+	}
+}
+
+func buildKeys(chainID, pk []byte, startHeight uint64, num uint64, options ...KeyBuildOption) [][]byte {
+	opts := &KeyBuildOptions{
+		interval: 1, // a default interval of 1 means consecutive heights
+	}
+
+	for _, option := range options {
+		option(opts)
+	}
+
 	keys := make([][]byte, 0, num)
 
 	for i := uint64(0); i < num; i++ {
-		height := startHeight + i*interval // 100, 105, 110, 115...
+		height := startHeight + i*opts.interval
 		key := getKey(chainID, pk, height)
 		keys = append(keys, key)
 	}
@@ -91,14 +102,19 @@ func buildKeysWithInterval(chainID, pk []byte, startHeight uint64, num uint64, i
 	return keys
 }
 
+// AddPubRandProofList adds a list of public randomness proofs to the store.
+// By default, it creates keys for consecutive heights starting from height.
+// Use WithInterval() option to specify a custom interval between heights.
+// For example, with height=100, numPubRand=3, WithInterval(5), it generates keys for heights [100, 105, 110].
 func (s *PubRandProofStore) AddPubRandProofList(
 	chainID []byte,
 	pk []byte,
 	height uint64,
 	numPubRand uint64,
 	proofList []*merkle.Proof,
+	options ...KeyBuildOption,
 ) error {
-	keys := buildKeys(chainID, pk, height, numPubRand)
+	keys := buildKeys(chainID, pk, height, numPubRand, options...)
 
 	if len(keys) != len(proofList) {
 		return fmt.Errorf("the number of public randomness is not same as the number of proofs")
@@ -129,53 +145,6 @@ func (s *PubRandProofStore) AddPubRandProofList(
 		return nil
 	}); err != nil {
 		return fmt.Errorf("failed to add pub rand proof list: %w", err)
-	}
-
-	return nil
-}
-
-// AddPubRandProofListWithInterval adds a list of public randomness proofs to the store with a given interval.
-// It creates keys for heights starting from startHeight and incrementing by interval for numPubRand entries.
-// For example, with startHeight=100, numPubRand=3, interval=5, it generates keys for heights [100, 105, 110].
-func (s *PubRandProofStore) AddPubRandProofListWithInterval(
-	chainID []byte,
-	pk []byte,
-	startHeight uint64,
-	numPubRand uint64,
-	proofList []*merkle.Proof,
-	interval uint64,
-) error {
-	keys := buildKeysWithInterval(chainID, pk, startHeight, numPubRand, interval)
-
-	if len(keys) != len(proofList) {
-		return fmt.Errorf("the number of public randomness is not same as the number of proofs")
-	}
-
-	var proofBytesList [][]byte
-	for _, proof := range proofList {
-		proofBytes, err := proof.ToProto().Marshal()
-		if err != nil {
-			return fmt.Errorf("invalid proof: %w", err)
-		}
-		proofBytesList = append(proofBytesList, proofBytes)
-	}
-
-	if err := kvdb.Batch(s.db, func(tx kvdb.RwTx) error {
-		bucket := tx.ReadWriteBucket(pubRandProofBucketName)
-		if bucket == nil {
-			return ErrCorruptedPubRandProofDB
-		}
-
-		for i, key := range keys {
-			// set to DB
-			if err := bucket.Put(key, proofBytesList[i]); err != nil {
-				return fmt.Errorf("failed to store pub rand proof: %w", err)
-			}
-		}
-
-		return nil
-	}); err != nil {
-		return fmt.Errorf("failed to add pub rand proof list with interval: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
Remove duplicate methods, use variadic options.

Closes https://github.com/babylonlabs-io/finality-provider/issues/635