### PR TITLE
chore: improve proof batch building

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Improvements
 
 * [#709](https://github.com/babylonlabs-io/finality-provider/pull/709) chore: query indexed block
+* [#711](https://github.com/babylonlabs-io/finality-provider/pull/711) chore: improve proof batch building
+
 
 ## v2.0.0-rc.4
 

--- a/finality-provider/service/finality_submitter.go
+++ b/finality-provider/service/finality_submitter.go
@@ -272,13 +272,11 @@ func (ds *DefaultFinalitySubmitter) submitBatchFinalitySignaturesOnce(ctx contex
 	}
 
 	numPubRand := uint32(len(blocks))
-	// Get public randomness for this specific height
 	prList, err := ds.GetPubRandList(blocks[0].GetHeight(), numPubRand)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get public randomness for height %d: %w", blocks[0].GetHeight(), err)
 	}
 
-	// Get proof for this specific height
 	proofBytesList, err := ds.ProofListGetterFunc(blocks[0].GetHeight(), uint64(numPubRand))
 	if err != nil {
 		return nil, fmt.Errorf("failed to get public randomness inclusion proof for height %d: %w\nplease recover the randomness proof from db", blocks[0].GetHeight(), err)

--- a/finality-provider/service/finality_submitter.go
+++ b/finality-provider/service/finality_submitter.go
@@ -271,6 +271,7 @@ func (ds *DefaultFinalitySubmitter) submitBatchFinalitySignaturesOnce(ctx contex
 		return nil, fmt.Errorf("should not submit batch finality signature with too many blocks")
 	}
 
+	// #nosec G115 -- performed the conversion check above
 	numPubRand := uint32(len(blocks))
 	prList, err := ds.GetPubRandList(blocks[0].GetHeight(), numPubRand)
 	if err != nil {


### PR DESCRIPTION
- bbn and cosmos fp have consecutive heights to vote, proof building can be reverted to the original impl, for rollups we use dedicated rollup-finality-submitter instance