### PR TITLE
fix: align pubrand and proof indexing with actual block heights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## Unreleased
 
+### Bug Fixes
+
+* [#777](https://github.com/babylonlabs-io/finality-provider/pull/777) fix: align pubrand and proof indexing with actual block heights
+
 ## v2.0.2
 
 ### Bug fixes

--- a/finality-provider/service/finality_submitter.go
+++ b/finality-provider/service/finality_submitter.go
@@ -266,20 +266,25 @@ func (ds *DefaultFinalitySubmitter) submitBatchFinalitySignaturesOnce(ctx contex
 		return nil, fmt.Errorf("should not submit batch finality signature with zero block")
 	}
 
-	if len(blocks) > math.MaxUint32 {
-		return nil, fmt.Errorf("should not submit batch finality signature with too many blocks")
+	// Compute the full height range covering all blocks (which may have gaps).
+	// We fetch pubrand/proofs for the entire consecutive range and index by offset.
+	startHeight := blocks[0].GetHeight()
+	endHeight := blocks[len(blocks)-1].GetHeight()
+	heightSpan := endHeight - startHeight + 1
+	if heightSpan > math.MaxUint32 {
+		return nil, fmt.Errorf("block height range too large: %d", heightSpan)
 	}
 
 	// #nosec G115 -- performed the conversion check above
-	numPubRand := uint32(len(blocks))
-	prList, err := ds.GetPubRandList(blocks[0].GetHeight(), numPubRand)
+	numPubRand := uint32(heightSpan)
+	prList, err := ds.GetPubRandList(startHeight, numPubRand)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get public randomness for height %d: %w", blocks[0].GetHeight(), err)
+		return nil, fmt.Errorf("failed to get public randomness for height %d: %w", startHeight, err)
 	}
 
-	proofBytesList, err := ds.ProofListGetterFunc(blocks[0].GetHeight(), uint64(numPubRand))
+	proofBytesList, err := ds.ProofListGetterFunc(startHeight, uint64(numPubRand))
 	if err != nil {
-		return nil, fmt.Errorf("failed to get public randomness inclusion proof for height %d: %w\nplease recover the randomness proof from db", blocks[0].GetHeight(), err)
+		return nil, fmt.Errorf("failed to get public randomness inclusion proof for height %d: %w\nplease recover the randomness proof from db", startHeight, err)
 	}
 
 	// Use batch signing for better performance
@@ -294,11 +299,12 @@ func (ds *DefaultFinalitySubmitter) submitBatchFinalitySignaturesOnce(ctx contex
 	validProofList := make([][]byte, 0, len(blocks))
 	validSigList := make([]*btcec.ModNScalar, 0, len(blocks))
 
-	for i, block := range blocks {
+	for _, block := range blocks {
 		if sig, found := batchSigMap[block.GetHeight()]; found {
+			offset := block.GetHeight() - startHeight
 			validBlocks = append(validBlocks, block)
-			validPrList = append(validPrList, prList[i])
-			validProofList = append(validProofList, proofBytesList[i])
+			validPrList = append(validPrList, prList[offset])
+			validProofList = append(validProofList, proofBytesList[offset])
 			validSigList = append(validSigList, sig.ToModNScalar())
 		} else {
 			// Block was skipped due to double-sign

--- a/finality-provider/service/fp_instance_test.go
+++ b/finality-provider/service/fp_instance_test.go
@@ -102,6 +102,75 @@ func FuzzSubmitFinalitySigs(f *testing.F) {
 	})
 }
 
+func TestSubmitFinalitySigsNonConsecutiveBlocks(t *testing.T) {
+	t.Parallel()
+	r := rand.New(rand.NewSource(42))
+
+	randomStartingHeight := uint64(10)
+	// We need blocks up to startingHeight+7, so currentHeight must cover that range
+	currentHeight := randomStartingHeight + 10
+	startingBlock := types.NewBlockInfo(randomStartingHeight, testutil.GenRandomByteArray(r, 32), false)
+	mockBabylonController := testutil.PrepareMockedBabylonController(t)
+	mockConsumerController := testutil.PrepareMockedConsumerController(t, r, randomStartingHeight, currentHeight)
+	mockConsumerController.EXPECT().QueryLatestBlock(t.Context()).Return(types.NewBlockInfo(0, testutil.GenRandomByteArray(r, 32), false), nil).AnyTimes()
+	mockConsumerController.EXPECT().GetFpRandCommitContext().Return("").AnyTimes()
+	mockConsumerController.EXPECT().GetFpFinVoteContext().Return("").AnyTimes()
+	mockConsumerController.EXPECT().IsBSN().Return(false).AnyTimes()
+	_, fpIns, cleanUp := startFinalityProviderAppWithRegisteredFp(t, r, mockBabylonController, mockConsumerController, true, randomStartingHeight, testutil.TestPubRandNum)
+	defer cleanUp()
+
+	// commit pub rand
+	_, err := fpIns.CommitPubRand(t.Context(), startingBlock.GetHeight())
+	require.NoError(t, err)
+
+	// mock committed pub rand
+	lastCommittedHeight := randomStartingHeight + 25
+	lastCommittedPubRand := &babylon.BabylonPubRandCommit{
+		StartHeight: lastCommittedHeight,
+		NumPubRand:  1000,
+		Commitment:  datagen.GenRandomByteArray(r, 32),
+		EpochNum:    5,
+	}
+	mockConsumerController.EXPECT().QueryLastPubRandCommit(t.Context(), gomock.Any()).Return(lastCommittedPubRand, nil).AnyTimes()
+
+	// Heights where FP does NOT have voting power — this creates gaps
+	heightsWithoutPower := map[uint64]bool{
+		randomStartingHeight + 2: true,
+		randomStartingHeight + 4: true,
+		randomStartingHeight + 5: true,
+	}
+
+	// mock voting power: return false for gap heights, true otherwise
+	mockConsumerController.EXPECT().QueryFinalityProviderHasPower(t.Context(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, req *api.QueryFinalityProviderHasPowerRequest) (bool, error) {
+			if heightsWithoutPower[req.BlockHeight] {
+				return false, nil
+			}
+			return true, nil
+		}).AnyTimes()
+
+	// create consecutive blocks from startingHeight+1 to startingHeight+7
+	var blocks []types.BlockDescription
+	for h := randomStartingHeight + 1; h <= randomStartingHeight+7; h++ {
+		blocks = append(blocks, types.NewBlockInfo(h, testutil.GenRandomByteArray(r, 32), false))
+	}
+
+	// after FilterBlocksForVoting, the resulting blocks should be non-consecutive:
+	// [+1, +3, +6, +7] (gaps at +2, +4, +5)
+	expectedTxHash := testutil.GenRandomHexStr(r, 32)
+	mockConsumerController.EXPECT().
+		SubmitBatchFinalitySigs(t.Context(), gomock.Any()).
+		Return(&types.TxResponse{TxHash: expectedTxHash}, nil).AnyTimes()
+
+	providerRes, err := fpIns.NewTestHelper().SubmitBatchFinalitySignatures(t, blocks)
+	require.NoError(t, err)
+	require.NotNil(t, providerRes)
+	require.Equal(t, expectedTxHash, providerRes.TxHash)
+
+	// check the last_voted_height is the highest block
+	require.Equal(t, randomStartingHeight+7, fpIns.GetLastVotedHeight())
+}
+
 func FuzzDetermineStartHeight(f *testing.F) {
 	testutil.AddRandomSeedsToFuzzer(f, 10)
 	f.Fuzz(func(t *testing.T, seed int64) {

--- a/finality-provider/service/fp_test_helper.go
+++ b/finality-provider/service/fp_test_helper.go
@@ -217,17 +217,22 @@ func (th *FinalityProviderTestHelper) SubmitBatchFinalitySignaturesAndExtractPri
 		return nil, nil, fmt.Errorf("should not submit batch finality signature with too many blocks")
 	}
 
-	// get public randomness list
-	numPubRand := len(blocks)
+	// get public randomness list for the full height range (blocks may have gaps)
+	startHeight := blocks[0].GetHeight()
+	endHeight := blocks[len(blocks)-1].GetHeight()
+	heightSpan := endHeight - startHeight + 1
 	// #nosec G115 -- performed the conversion check above
-	prList, err := th.fp.GetPubRandList(blocks[0].GetHeight(), uint32(numPubRand))
+	allPrList, err := th.fp.GetPubRandList(startHeight, uint32(heightSpan))
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get public randomness list: %w", err)
 	}
 
-	// get proof list
-	proofBytesList := make([][]byte, 0, numPubRand)
+	// build filtered pubrand and proof lists indexed by actual block height
+	prList := make([]*btcec.FieldVal, 0, len(blocks))
+	proofBytesList := make([][]byte, 0, len(blocks))
 	for _, b := range blocks {
+		offset := b.GetHeight() - startHeight
+		prList = append(prList, allPrList[offset])
 		proofBytes, err := th.fp.pubRandState.getPubRandProof(th.fp.btcPk.MustMarshal(), th.fp.GetChainID(), b.GetHeight())
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to get public randomness inclusion proof: %w", err)


### PR DESCRIPTION
  - Fix height misalignment between public randomness/Merkle proofs and finality signatures when `FilterBlocksForVoting` produces non-consecutive block arrays (e.g. `[100, 102, 103]` after removing blocks
  where the FP lacks voting power)
  - Fetch pubrand and proofs for the full height span (`endHeight - startHeight + 1`) and index by `block.GetHeight() - startHeight` offset instead of array index
  - Apply the same fix to the test helper `SubmitBatchFinalitySignaturesAndExtractPrivKey` for consistency